### PR TITLE
Fixes for SBZ Forcefield and OOZ BallCannon

### DIFF
--- a/Sonic 1/Scripts/SBZ/ForceField.txt
+++ b/Sonic 1/Scripts/SBZ/ForceField.txt
@@ -50,30 +50,47 @@ end function
 
 
 event ObjectMain
-	foreach (GROUP_PLAYERS, currentPlayer, ACTIVE_ENTITIES)
-		BoxCollisionTest(C_BOX, object.entityPos, -8, -80, 8, 80, currentPlayer, HITBOX_AUTO, HITBOX_AUTO, HITBOX_AUTO, HITBOX_AUTO)
-	next
+	switch object.state
+	case 0
+		if stage.actNum == 2
+			temp0 = object[0].xpos
+			temp0 >>= 16
+			if temp0 > 8470
+				object.state = 1
+			endif
+		else
+			object.state = 1
+		endif
+		break
+	case 1
+		foreach (GROUP_PLAYERS, currentPlayer, ACTIVE_ENTITIES)
+			BoxCollisionTest(C_BOX, object.entityPos, -8, -80, 8, 80, currentPlayer, HITBOX_AUTO, HITBOX_AUTO, HITBOX_AUTO, HITBOX_AUTO)
+		next
+	endswitch
+	DrawNumbers(0, 104, 50, object.xpos, 6, 8, 0)
 end event
 
 
 event ObjectDraw
-	temp1 = oscillation
-	temp1 <<= 2
-	Sin(temp0, temp1)
-	object.alpha = temp0
-	object.alpha >>= 5
-	object.alpha += 80
-	DrawSpriteFX(0, FX_INK, object.xpos, object.ypos)
-	DrawSpriteFX(4, FX_INK, object.xpos, object.ypos)
-	object.alpha = temp0
-	object.alpha >>= 5
-	object.alpha += 144
-	DrawSpriteFX(1, FX_INK, object.xpos, object.ypos)
-	DrawSpriteFX(3, FX_INK, object.xpos, object.ypos)
-	object.alpha = temp0
-	object.alpha >>= 4
-	object.alpha += 192
-	DrawSpriteFX(2, FX_INK, object.xpos, object.ypos)
+	if object.state == 1
+		temp1 = oscillation
+		temp1 <<= 2
+		Sin(temp0, temp1)
+		object.alpha = temp0
+		object.alpha >>= 5
+		object.alpha += 80
+		DrawSpriteFX(0, FX_INK, object.xpos, object.ypos)
+		DrawSpriteFX(4, FX_INK, object.xpos, object.ypos)
+		object.alpha = temp0
+		object.alpha >>= 5
+		object.alpha += 144
+		DrawSpriteFX(1, FX_INK, object.xpos, object.ypos)
+		DrawSpriteFX(3, FX_INK, object.xpos, object.ypos)
+		object.alpha = temp0
+		object.alpha >>= 4
+		object.alpha += 192
+		DrawSpriteFX(2, FX_INK, object.xpos, object.ypos)
+	endif
 end event
 
 

--- a/Sonic 1/Scripts/SBZ/ForceField.txt
+++ b/Sonic 1/Scripts/SBZ/ForceField.txt
@@ -52,7 +52,7 @@ end function
 event ObjectMain
 	switch object.state
 	case 0
-		if stage.actNum == 2
+		if stage.actNum == 2 //In Act 2, check player position before activating
 			temp0 = object[0].xpos
 			temp0 >>= 16
 			if temp0 > 8470

--- a/Sonic 2/Scripts/OOZ/BallCannon.txt
+++ b/Sonic 2/Scripts/OOZ/BallCannon.txt
@@ -223,6 +223,11 @@ event ObjectMain
 				end if
 				PlaySfx(SfxName[Rolling], 0)
 			end if
+		else
+			temp0 = 1	//if character is not in the cannon, make sure it doesn't shoot them
+			temp0 <<= currentPlayer
+			object.value5 |= temp0
+			object.value5 ^= temp0
 		end if
 	next
 	if object.outOfBounds == 1


### PR DESCRIPTION
Forcefield changes to let characters through at the end of Scrap Brain Zone act 2, by only activating when the player is at a certain point in the level (past it).

BallCannon changes. As it was, a second character could enter the cannon within 16 frames of a first character leaving it, and the resulting fire would shoot both characters. This ensures players who have left the cannon are not affected.