### PR TITLE
Jump changes

### DIFF
--- a/Sonic 1/Scripts/Ending/EndingSetup.txt
+++ b/Sonic 1/Scripts/Ending/EndingSetup.txt
@@ -163,7 +163,14 @@ event ObjectStartup
 	temp0 = 424
 	temp0 -= screen.xcenter
 	stage.newXBoundary1 = temp0
-	if specialStage.emeralds < 63
+
+	if options.superStates == 0
+		temp1 = 63
+	else
+		temp1 = 127
+	end if
+
+	if specialStage.emeralds < temp1
 		temp0 = tileLayer[0].xsize
 		temp0 <<= 7
 		temp0 -= 256

--- a/Sonic 1/Scripts/Players/PlayerObject.txt
+++ b/Sonic 1/Scripts/Players/PlayerObject.txt
@@ -1448,6 +1448,11 @@ function PlayerObject_StartJump
 			object.state = PlayerObject_HandleAir
 		end if
 		PlaySfx(SfxName[Jump], 0)
+		
+		temp0 = 5
+		temp0 <<= 16
+		object.ypos -= temp0
+		
 		object.value34 = 1
 		object.value35 = 1
 	end if

--- a/Sonic 2/Scripts/Players/PlayerObject.txt
+++ b/Sonic 2/Scripts/Players/PlayerObject.txt
@@ -1478,6 +1478,11 @@ function PlayerObject_StartJump
 			object.state = PlayerObject_HandleAir
 		end if
 		PlaySfx(SfxName[Jump], 0)
+		
+		temp0 = 5
+		temp0 <<= 16
+		object.ypos -= temp0
+	
 		object.value34 = 1
 		object.value35 = 1
 	end if


### PR DESCRIPTION
Currently the scripts allow a player to jump extremely high from shallow water. This fixes it by allowing the player to jump without moving down.