### PR TITLE
Fix life subtraction when drowning in Sonic 2

### DIFF
--- a/Sonic 2/Scripts/Players/PlayerObject.txt
+++ b/Sonic 2/Scripts/Players/PlayerObject.txt
@@ -3297,8 +3297,8 @@ function PlayerObject_Drown
 		if object.value16 == 0
 			arrayPos0 = 25
 			arrayPos0 += object.entityPos
-			if options.gameMode > 0
-				options.gameMode--
+			if player.lives > 0
+				player.lives--
 			end if
 			if options.vsMode == 0
 				stage.timeEnabled = 0


### PR DESCRIPTION
When drowning in Sonic 2, the script checks the variable options.gameMode and subtracts 1 from it if it's greater than 0, however it should be using the variable player.lives instead.