### PR TITLE
Fix more death related bugs in Sonic 2

### DIFF
--- a/Sonic 2/Scripts/Players/PlayerObject.txt
+++ b/Sonic 2/Scripts/Players/PlayerObject.txt
@@ -3205,7 +3205,7 @@ function PlayerObject_Death
 					object.value3 = 0
 					object.state = 3
 				else
-					if options.gameMode == 0
+					if player.lives == 0
 						object.value3 = -0xB40
 						object.state = 0
 						PlayMusic(5)
@@ -3222,7 +3222,7 @@ function PlayerObject_Death
 					end if
 				end if
 			else
-				if options.gameMode == 0
+				if player.lives == 0
 					object.type = TypeName[Death Event]
 					object.state = 0
 				end if


### PR DESCRIPTION
I found more instances of options.gameMode that should be player.lives.