### PR TITLE
Change function checks/calls to use proper names

### DIFF
--- a/Sonic 1/Scripts/Global/BlueShield.txt
+++ b/Sonic 1/Scripts/Global/BlueShield.txt
@@ -15,10 +15,10 @@ private alias 24 : TYPE_BLUESHIELD
 
 event ObjectMain
 	object.drawOrder = -1
-	if object[-playerCount].state == 27
+	if object[-playerCount].state == PlayerObject_Death
 		object.type = TypeName[Blank Object]
 	end if
-	if object[-playerCount].state == 28
+	if object[-playerCount].state == PlayerObject_Drown
 		object.type = TypeName[Blank Object]
 	end if
 	object.value0++

--- a/Sonic 1/Scripts/Global/BlueShield2.txt
+++ b/Sonic 1/Scripts/Global/BlueShield2.txt
@@ -15,10 +15,10 @@ private alias 25 : TYPE_BLUESHIELD2
 
 event ObjectMain
 	object.drawOrder = -1
-	if object[-playerCount].state == 27
+	if object[-playerCount].state == PlayerObject_Death
 		object.type = TypeName[Blank Object]
 	end if
-	if object[-playerCount].state == 28
+	if object[-playerCount].state == PlayerObject_Drown
 		object.type = TypeName[Blank Object]
 	end if
 	object.frame = object.value0

--- a/Sonic 1/Scripts/Global/BubbleShield.txt
+++ b/Sonic 1/Scripts/Global/BubbleShield.txt
@@ -21,10 +21,10 @@ end table
 
 
 event ObjectMain
-	if object[-playerCount].state == 27
+	if object[-playerCount].state == PlayerObject_Death
 		object.type = TypeName[Blank Object]
 	end if
-	if object[-playerCount].state == 28
+	if object[-playerCount].state == PlayerObject_Drown
 		object.type = TypeName[Blank Object]
 	end if
 	object.drawOrder = -1

--- a/Sonic 1/Scripts/Global/FireShield.txt
+++ b/Sonic 1/Scripts/Global/FireShield.txt
@@ -24,10 +24,10 @@ end table
 
 event ObjectMain
 	object.drawOrder = -1
-	if object[-playerCount].state == 27
+	if object[-playerCount].state == PlayerObject_Death
 		object.type = TypeName[Blank Object]
 	end if
-	if object[-playerCount].state == 28
+	if object[-playerCount].state == PlayerObject_Drown
 		object.type = TypeName[Blank Object]
 	end if
 	switch object.state

--- a/Sonic 1/Scripts/Global/InstaShield.txt
+++ b/Sonic 1/Scripts/Global/InstaShield.txt
@@ -14,10 +14,10 @@ private alias 26 : TYPE_INSTASHIELD
 // Tables
 
 event ObjectMain
-	if object[-playerCount].state == 27
+	if object[-playerCount].state == PlayerObject_Death
 		object.type = TypeName[Blank Object]
 	end if
-	if object[-playerCount].state == 28
+	if object[-playerCount].state == PlayerObject_Drown
 		object.type = TypeName[Blank Object]
 	end if
 	object.drawOrder = -1

--- a/Sonic 1/Scripts/Global/LightningShield.txt
+++ b/Sonic 1/Scripts/Global/LightningShield.txt
@@ -33,10 +33,10 @@ end table
 
 event ObjectMain
 	object.drawOrder = 7
-	if object[-playerCount].state == 27
+	if object[-playerCount].state == PlayerObject_Death
 		object.type = TypeName[Blank Object]
 	end if
-	if object[-playerCount].state == 28
+	if object[-playerCount].state == PlayerObject_Drown
 		object.type = TypeName[Blank Object]
 	end if
 	object.animationTimer--

--- a/Sonic 2/Scripts/CNZ/CNZSetup.txt
+++ b/Sonic 2/Scripts/CNZ/CNZSetup.txt
@@ -65,7 +65,7 @@ end table
 
 function CNZSetup_Function97
 	if object.gravity == GRAVITY_AIR
-		object.state = 98
+		object.state = CNZSetup_Function98
 		object.value1 = 0
 		CallFunction(PlayerObject_HandleAirMovement)
 	else
@@ -139,7 +139,7 @@ function CNZSetup_Function98
 	if object.gravity == GRAVITY_AIR
 		CallFunction(PlayerObject_HandleAirMovement)
 	else
-		object.state = 97
+		object.state = CNZSetup_Function97
 		CallFunction(PlayerObject_ResetOnFloor)
 		object.value14 = 0
 	end if

--- a/Sonic 2/Scripts/Global/BlueShield.txt
+++ b/Sonic 2/Scripts/Global/BlueShield.txt
@@ -15,10 +15,10 @@ private alias 24 : TYPE_BLUESHIELD
 
 event ObjectMain
 	object.drawOrder = -1
-	if object[-playerCount].state == 28
+	if object[-playerCount].state == PlayerObject_Death
 		object.type = TypeName[Blank Object]
 	end if
-	if object[-playerCount].state == 29
+	if object[-playerCount].state == PlayerObject_Drown
 		object.type = TypeName[Blank Object]
 	end if
 	object.frame = object.value0

--- a/Sonic 2/Scripts/Global/BubbleShield.txt
+++ b/Sonic 2/Scripts/Global/BubbleShield.txt
@@ -21,10 +21,10 @@ end table
 
 
 event ObjectMain
-	if object[-playerCount].state == 28
+	if object[-playerCount].state == PlayerObject_Death
 		object.type = TypeName[Blank Object]
 	end if
-	if object[-playerCount].state == 29
+	if object[-playerCount].state == PlayerObject_Drown
 		object.type = TypeName[Blank Object]
 	end if
 	object.drawOrder = -1

--- a/Sonic 2/Scripts/Global/FireShield.txt
+++ b/Sonic 2/Scripts/Global/FireShield.txt
@@ -24,10 +24,10 @@ end table
 
 event ObjectMain
 	object.drawOrder = -1
-	if object[-playerCount].state == 28
+	if object[-playerCount].state == PlayerObject_Death
 		object.type = TypeName[Blank Object]
 	end if
-	if object[-playerCount].state == 29
+	if object[-playerCount].state == PlayerObject_Drown
 		object.type = TypeName[Blank Object]
 	end if
 	switch object.state

--- a/Sonic 2/Scripts/Global/InstaShield.txt
+++ b/Sonic 2/Scripts/Global/InstaShield.txt
@@ -14,10 +14,10 @@ private alias 25 : TYPE_INSTASHIELD
 // Tables
 
 event ObjectMain
-	if object[-playerCount].state == 28
+	if object[-playerCount].state == PlayerObject_Death
 		object.type = TypeName[Blank Object]
 	end if
-	if object[-playerCount].state == 29
+	if object[-playerCount].state == PlayerObject_Drown
 		object.type = TypeName[Blank Object]
 	end if
 	object.drawOrder = -1

--- a/Sonic 2/Scripts/Global/LightningShield.txt
+++ b/Sonic 2/Scripts/Global/LightningShield.txt
@@ -33,10 +33,10 @@ end table
 
 event ObjectMain
 	object.drawOrder = 7
-	if object[-playerCount].state == 28
+	if object[-playerCount].state == PlayerObject_Death
 		object.type = TypeName[Blank Object]
 	end if
-	if object[-playerCount].state == 29
+	if object[-playerCount].state == PlayerObject_Drown
 		object.type = TypeName[Blank Object]
 	end if
 	object.animationTimer--

--- a/Sonic 2/Scripts/Global/SuperSpark.txt
+++ b/Sonic 2/Scripts/Global/SuperSpark.txt
@@ -70,7 +70,7 @@ event ObjectMain
 			temp0 = checkResult
 			CheckEqual(object[-playerCount].value42, 0)
 			temp0 &= checkResult
-			CheckEqual(object[-playerCount].state, 24)
+			CheckEqual(object[-playerCount].state, PlayerObject_KnuxWallClimb)
 			temp0 |= checkResult
 			if temp0 == 1
 				object.state = 0

--- a/Sonic 2/Scripts/MBZ/MBZSetup.txt
+++ b/Sonic 2/Scripts/MBZ/MBZSetup.txt
@@ -47,7 +47,7 @@ function MBZSetup_Function97
 	end if
 	CallFunction(PlayerObject_HandleMovement)
 	if object.gravity == GRAVITY_AIR
-		object.state = 12
+		object.state = PlayerObject_HandleAir
 		CallFunction(PlayerObject_HandleAirMovement)
 	else
 		CallFunction(PlayerObject_ResetOnFloor)

--- a/Sonic 2/Scripts/OOZ/OOZSetup.txt
+++ b/Sonic 2/Scripts/OOZ/OOZSetup.txt
@@ -62,7 +62,7 @@ function OOZSetup_Function98
 	end if
 	CallFunction(PlayerObject_HandleMovement)
 	if object.gravity == GRAVITY_AIR
-		object.state = 12
+		object.state = PlayerObject_HandleAir
 		CallFunction(PlayerObject_HandleAirMovement)
 	else
 		CallFunction(PlayerObject_ResetOnFloor)
@@ -249,7 +249,7 @@ end function
 function OOZSetup_Function100
 	CallFunction(OOZSetup_Function99)
 	if object.gravity == GRAVITY_AIR
-		object.state = 12
+		object.state = PlayerObject_HandleAir
 		CallFunction(PlayerObject_HandleAirMovement)
 	else
 		CallFunction(PlayerObject_ResetOnFloor)

--- a/Sonic 2/Scripts/Players/PlayerObject.txt
+++ b/Sonic 2/Scripts/Players/PlayerObject.txt
@@ -675,12 +675,12 @@ end function
 
 
 function PlayerObject_Hit
-	if object[currentPlayer].state != 28
+	if object[currentPlayer].state != PlayerObject_Death
 		arrayPos0 = object[currentPlayer].entityPos
 		arrayPos0 += playerCount
 		if object[currentPlayer].value7 == 0
 			if object[currentPlayer].value8 == 0
-				object[currentPlayer].state = 26
+				object[currentPlayer].state = PlayerObject_Hurt
 				if object[currentPlayer].xpos > object.xpos
 					object[currentPlayer].speed = 0x20000
 				else
@@ -1575,7 +1575,7 @@ function PlayerObject_BubbleBounce
 			CallFunction(PlayerObject_RollAnimSpd)
 			object.state = PlayerObject_HandleAir
 			PlaySfx(SfxName[Bubble Bounce], 0)
-			object[+playerCount].state = 4
+			object[+playerCount].state = PlayerObject_HandleAirMovement
 		end if
 	end if
 end function

--- a/Sonic 2/Scripts/Players/PlayerObject.txt
+++ b/Sonic 2/Scripts/Players/PlayerObject.txt
@@ -1575,7 +1575,7 @@ function PlayerObject_BubbleBounce
 			CallFunction(PlayerObject_RollAnimSpd)
 			object.state = PlayerObject_HandleAir
 			PlaySfx(SfxName[Bubble Bounce], 0)
-			object[+playerCount].state = PlayerObject_HandleAirMovement
+			object[+playerCount].state = 4
 		end if
 	end if
 end function


### PR DESCRIPTION
Some checks/calls for functions refer to functions by their number rather than names. While this works fine and causes no issues normally, it can lead to bugs when writing script mods that add new functions. These commits attempt to prevent said bugs.