### PR TITLE
Make Debug Mode refer to PlayerObject functions by name

### DIFF
--- a/Sonic 1/Scripts/Global/DebugMode.txt
+++ b/Sonic 1/Scripts/Global/DebugMode.txt
@@ -199,7 +199,7 @@ event ObjectMain
 		object.speed = 0
 		object.xvel = 0
 		object.yvel = 0
-		object.state = 11
+		object.state = PlayerObject_HandleAir
 		object.animation = ANI_WALKING
 		object.animationSpeed = 0
 		object.frame = 0

--- a/Sonic 2/Scripts/Global/DebugMode.txt
+++ b/Sonic 2/Scripts/Global/DebugMode.txt
@@ -234,7 +234,7 @@ event ObjectMain
 				object.speed = 0
 				object.xvel = 0
 				object.yvel = 0
-				object.state = 12
+				object.state = PlayerObject_HandleAir
 				object.animation = ANI_WALKING
 				object.animationSpeed = 0
 				object.frame = 0


### PR DESCRIPTION
A similar commit to the previous one, this time changing the Debug Mode objects to refer to PlayerObject functions by name instead of number to help mods break less.