### PR TITLE
Revert OOZ cannon fix

### DIFF
--- a/Sonic 2/Scripts/OOZ/BallCannon.txt
+++ b/Sonic 2/Scripts/OOZ/BallCannon.txt
@@ -223,11 +223,6 @@ event ObjectMain
 				end if
 				PlaySfx(SfxName[Rolling], 0)
 			end if
-		else
-			temp0 = 1	//if character is not in the cannon, make sure it doesn't shoot them
-			temp0 <<= currentPlayer
-			object.value5 |= temp0
-			object.value5 ^= temp0
 		end if
 	next
 	if object.outOfBounds == 1


### PR DESCRIPTION
The OOZ cannon fix is a fix to a bug found in the original ByteCode scripts, which is against the goal of the decompilation project. This commit reverts the behavior back to the bugged, intended state.