### PR TITLE
Fix issue with Tails's tails while running

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# top-most EditorConfig file
+root = true
+
+# enforce our RetroScript needs here
+[*.txt]
+end_of_line = crlf
+indent_style = tab
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,0 @@
-# default behaviour
-* text=auto
-
-# S1/2 Script files must ALWAYS use crlf line endings
-*.txt text eol=crlf

--- a/Sonic 1/Scripts/GHZ/GHZSetup.txt
+++ b/Sonic 1/Scripts/GHZ/GHZSetup.txt
@@ -16,23 +16,25 @@ private alias object.value3 : object.paletteTimer
 private alias object.value4 : object.waterfallLoopTimer
 private alias object.value5 : object.playingWaterfallLoop
 
+
 // ========================
 // Function Declarations
 // ========================
 reserve function GHZSetup_SpeedUpMusic
 reserve function GHZSetup_SlowDownMusic
 
+
 // ========================
 // Static Values
 // ========================
-public value GHZSetup_spikeLogsCounter 		= 0
-public value GHZSetup_playingWaterfallSfx 	= false
-public value GHZSetup_waterfallPan 			= 0
+public value GHZSetup_value29 = 0
+public value GHZSetup_value30 = false
+public value GHZSetup_value31 = 0
 
 // Kept here for mod compatability reasons, please don't use these if possible
-public alias GHZSetup_spikeLogsCounter 		: GHZSetup_value29
-public alias GHZSetup_playingWaterfallSfx	: GHZSetup_value30
-public alias GHZSetup_waterfallPan 			: GHZSetup_value31
+private alias GHZSetup_value29 : GHZSetup_spikeLogsCounter
+private alias GHZSetup_value30 : GHZSetup_playingWaterfallSfx
+private alias GHZSetup_value31 : GHZSetup_waterfallPan
 
 // Tracks
 private alias 0 : TRACK_STAGE
@@ -59,6 +61,7 @@ private alias 502294 : MUSIC_LOOP_GHZ_F // ...but this sped-up version had its l
 
 private alias 39528  : MUSIC_LOOP_INV
 private alias 30436  : MUSIC_LOOP_INV_F
+
 
 // ========================
 // Tables
@@ -399,6 +402,7 @@ function GHZSetup_SlowDownMusic
 		stage.musicFlag = MUSICEVENT_FLAG_SLOWDOWN
 	end if
 end function
+
 
 // ========================
 // Events

--- a/Sonic 1/Scripts/GHZ/SpikeLogs.txt
+++ b/Sonic 1/Scripts/GHZ/SpikeLogs.txt
@@ -11,7 +11,7 @@
 private alias object.value1 : object.spikedLog
 
 // Kept here for mod compatability reasons, please don't use this if possible
-private alias GHZSetup_spikeLogsCounter : GHZSetup_value29
+private alias GHZSetup_value29 : GHZSetup_spikeLogsCounter
 
 // ========================
 // Function Declarations

--- a/Sonic 1/Scripts/GHZ/WaterfallSound.txt
+++ b/Sonic 1/Scripts/GHZ/WaterfallSound.txt
@@ -18,8 +18,9 @@ private alias object.value0 : object.unused1
 private alias object.value1 : object.unused2
 
 // Kept here for mod compatability reasons, please don't use these if possible
-private alias GHZSetup_playingWaterfallSfx	: GHZSetup_value30
-private alias GHZSetup_waterfallPan			: GHZSetup_value31
+private alias GHZSetup_value30 : GHZSetup_playingWaterfallSfx
+private alias GHZSetup_value31 : GHZSetup_waterfallPan
+
 
 event ObjectMain
 	object.priority = PRIORITY_ACTIVE

--- a/Sonic 1/Scripts/LZ/LZSetup.txt
+++ b/Sonic 1/Scripts/LZ/LZSetup.txt
@@ -46,7 +46,6 @@ private alias 10 : SLOT_ZONESETUP
 private alias 25 : SLOT_MUSICEVENT_CHANGE
 private alias 26 : SLOT_MUSICEVENT_BOSS
 
-
 // Music Events
 private alias 0 : MUSICEVENT_FADETOBOSS
 private alias 1 : MUSICEVENT_FADETOSTAGE
@@ -55,6 +54,16 @@ private alias 2 : MUSICEVENT_TRANSITION
 private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
+
+// Music Loops
+private alias 84444 : MUSIC_LOOP_LZ
+private alias 67538 : MUSIC_LOOP_LZ_F
+
+private alias 1     : MUSIC_LOOP_SBZ
+private alias 1     : MUSIC_LOOP_SBZ_F
+
+private alias 39528 : MUSIC_LOOP_INV
+private alias 30436 : MUSIC_LOOP_INV_F
 
 
 // ========================
@@ -721,19 +730,19 @@ function LZSetup_SpeedUpMusicLZ
 	if temp0 == 0
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436)
-			SwapMusicTrack("Labyrinth_F.ogg", TRACK_STAGE, 67538, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("Labyrinth_F.ogg", TRACK_STAGE, MUSIC_LOOP_LZ_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("Labyrinth_F.ogg", TRACK_STAGE, 67538)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436, 8000)
+			SetMusicTrack("Labyrinth_F.ogg", TRACK_STAGE, MUSIC_LOOP_LZ_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
-			SetMusicTrack("Labyrinth_F.ogg", TRACK_STAGE, 67538)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436)
+			SetMusicTrack("Labyrinth_F.ogg", TRACK_STAGE, MUSIC_LOOP_LZ_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -752,19 +761,19 @@ function LZSetup_SlowDownMusicLZ
 	if temp0 == 0
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528)
-			SwapMusicTrack("Labyrinth.ogg", TRACK_STAGE, 84444, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("Labyrinth.ogg", TRACK_STAGE, MUSIC_LOOP_LZ, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("Labyrinth.ogg", TRACK_STAGE, 84444)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528, 12500)
+			SetMusicTrack("Labyrinth.ogg", TRACK_STAGE, MUSIC_LOOP_LZ)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
-			SetMusicTrack("Labyrinth.ogg", TRACK_STAGE, 84444)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528)
+			SetMusicTrack("Labyrinth.ogg", TRACK_STAGE, MUSIC_LOOP_LZ)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -784,19 +793,19 @@ function LZSetup_SpeedUpMusicSBZ3
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436)
-			SwapMusicTrack("ScrapBrain_F.ogg", TRACK_STAGE, true, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("ScrapBrain_F.ogg", TRACK_STAGE, MUSIC_LOOP_SBZ_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("ScrapBrain_F.ogg", TRACK_STAGE, true)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436, 8000)
+			SetMusicTrack("ScrapBrain_F.ogg", TRACK_STAGE, MUSIC_LOOP_SBZ_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
-			SetMusicTrack("ScrapBrain_F.ogg", TRACK_STAGE, true)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436)
+			SetMusicTrack("ScrapBrain_F.ogg", TRACK_STAGE, MUSIC_LOOP_SBZ_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -816,19 +825,19 @@ function LZSetup_SlowDownMusicSBZ3
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", 2, 39528)
-			SwapMusicTrack("ScrapBrain.ogg", TRACK_STAGE, true, 12500)
+			SetMusicTrack("Invincibility.ogg", 2, MUSIC_LOOP_INV)
+			SwapMusicTrack("ScrapBrain.ogg", TRACK_STAGE, MUSIC_LOOP_SBZ, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("ScrapBrain.ogg", TRACK_STAGE, true)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528, 12500)
+			SetMusicTrack("ScrapBrain.ogg", TRACK_STAGE, MUSIC_LOOP_SBZ)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
-			SetMusicTrack("ScrapBrain.ogg", TRACK_STAGE, true)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528)
+			SetMusicTrack("ScrapBrain.ogg", TRACK_STAGE, MUSIC_LOOP_SBZ)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -990,12 +999,12 @@ event ObjectStartup
 	// If in act 1-3, set the normal Labyrinth music
 	if stage.actNum < 4
 		// Set the speed up/slow down functions, too
-		SetMusicTrack("Labyrinth.ogg", TRACK_STAGE, 84444)
+		SetMusicTrack("Labyrinth.ogg", TRACK_STAGE, MUSIC_LOOP_LZ)
 		SpeedUpMusic = LZSetup_SpeedUpMusicLZ
 		SlowDownMusic = LZSetup_SlowDownMusicLZ
 	else
 		// If in "act 4", or SBZ 3, then use Scrap Brain's music instead
-		SetMusicTrack("ScrapBrain.ogg", TRACK_STAGE, true)
+		SetMusicTrack("ScrapBrain.ogg", TRACK_STAGE, MUSIC_LOOP_SBZ)
 		SpeedUpMusic = LZSetup_SpeedUpMusicSBZ3
 		SlowDownMusic = LZSetup_SlowDownMusicSBZ3
 	end if

--- a/Sonic 1/Scripts/LevelSelect/BGAnimation.txt
+++ b/Sonic 1/Scripts/LevelSelect/BGAnimation.txt
@@ -13,10 +13,11 @@ private alias object.value0 : object.bgTimer
 // ========================
 // Static Values
 // ========================
-public value BGAnimation_currentPreview = 0
+public value BGAnimation_value0 = 0
 
 // Kept here for mod compatability reasons, please don't use this if possible
-private alias BGAnimation_currentPreview : BGAnimation_value0
+private alias BGAnimation_value0 : BGAnimation_currentPreview
+
 
 event ObjectMain
 	// Move the camera to the proper position

--- a/Sonic 1/Scripts/LevelSelect/MenuControl.txt
+++ b/Sonic 1/Scripts/LevelSelect/MenuControl.txt
@@ -34,6 +34,17 @@ private alias 1 : MENUCONTROL_SHIELD_S2
 private alias 2 : MENUCONTROL_SHIELD_S3_S1
 private alias 3 : MENUCONTROL_SHIELD_S3_S2
 
+// Music loops
+private alias 635050 : MUSIC_LOOP_GHZ // 635970 in older S1 versions, changed some time around 1.0.7
+private alias 99380  : MUSIC_LOOP_MZ
+private alias 100712 : MUSIC_LOOP_SYZ // This is 101364 in the normal stage...
+private alias 84444  : MUSIC_LOOP_LZ
+private alias 84364  : MUSIC_LOOP_SLZ
+private alias 1      : MUSIC_LOOP_SBZ
+private alias 84680  : MUSIC_LOOP_FINAL
+private alias 39528  : MUSIC_LOOP_INV
+
+
 // ========================
 // Function Declarations
 // ========================
@@ -46,8 +57,8 @@ reserve function MenuControl_PlaySong
 private value MenuControl_DebugCheatCodePos 	= 0
 private value MenuControl_EmeraldCheatCodePos 	= 0
 
-// Kept here for mod compatability reasons, please don't use this if possible
-private alias BGAnimation_currentPreview : BGAnimation_value0
+private alias BGAnimation_value0 : BGAnimation_currentPreview
+
 
 // ========================
 // Tables
@@ -137,7 +148,7 @@ end function
 
 
 function MenuControl_PlaySong
-	// Don't play songs in quick succession
+	// Don't allow playing of songs in quick succession
 	if object.soundTestCooldown == 0
 		object.soundTestCooldown = 30
 
@@ -147,37 +158,37 @@ function MenuControl_PlaySong
 			break
 
 		case 1
-			SetMusicTrack("GreenHill.ogg", 0, 635050)
+			SetMusicTrack("GreenHill.ogg", 0, MUSIC_LOOP_GHZ)
 			PlayMusic(0)
 			break
 
 		case 2
-			SetMusicTrack("Marble.ogg", 0, 99380)
+			SetMusicTrack("Marble.ogg", 0, MUSIC_LOOP_MZ)
 			PlayMusic(0)
 			break
 
 		case 3
-			SetMusicTrack("SpringYard.ogg", 0, 100712)
+			SetMusicTrack("SpringYard.ogg", 0, MUSIC_LOOP_SYZ)
 			PlayMusic(0)
 			break
 
 		case 4
-			SetMusicTrack("Labyrinth.ogg", 0, 84444)
+			SetMusicTrack("Labyrinth.ogg", 0, MUSIC_LOOP_LZ)
 			PlayMusic(0)
 			break
 
 		case 5
-			SetMusicTrack("Starlight.ogg", 0, 84364)
+			SetMusicTrack("Starlight.ogg", 0, MUSIC_LOOP_SLZ)
 			PlayMusic(0)
 			break
 
 		case 6
-			SetMusicTrack("ScrapBrain.ogg", 0, true)
+			SetMusicTrack("ScrapBrain.ogg", 0, MUSIC_LOOP_SBZ)
 			PlayMusic(0)
 			break
 
 		case 7
-			SetMusicTrack("Invincibility.ogg", 0, 39528)
+			SetMusicTrack("Invincibility.ogg", 0, MUSIC_LOOP_INV)
 			PlayMusic(0)
 			break
 
@@ -209,7 +220,7 @@ function MenuControl_PlaySong
 			break
 
 		case 13
-			SetMusicTrack("Final.ogg", 0, 84680)
+			SetMusicTrack("Final.ogg", 0, MUSIC_LOOP_FINAL)
 			PlayMusic(0)
 			break
 

--- a/Sonic 1/Scripts/MZ/MZSetup.txt
+++ b/Sonic 1/Scripts/MZ/MZSetup.txt
@@ -41,6 +41,13 @@ private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
 
+// Music loops
+private alias 99380 : MUSIC_LOOP_MZ
+private alias 79537 : MUSIC_LOOP_MZ_F
+
+private alias 39528 : MUSIC_LOOP_INV
+private alias 30436 : MUSIC_LOOP_INV_F
+
 
 // ========================
 // Function Declarations
@@ -417,18 +424,18 @@ function MZSetup_SpeedUpMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436)
-			SwapMusicTrack("Marble_F.ogg", TRACK_STAGE, 79537, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("Marble_F.ogg", TRACK_STAGE, MUSIC_LOOP_MZ_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("Marble_F.ogg", TRACK_STAGE, 79537)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436, 8000)
+			SetMusicTrack("Marble_F.ogg", TRACK_STAGE, MUSIC_LOOP_MZ_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
-			SetMusicTrack("Marble_F.ogg", TRACK_STAGE, 79537)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436)
+			SetMusicTrack("Marble_F.ogg", TRACK_STAGE, MUSIC_LOOP_MZ_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -447,18 +454,18 @@ function MZSetup_SpeedUpMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528)
-			SwapMusicTrack("Marble.ogg", TRACK_STAGE, 99380, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("Marble.ogg", TRACK_STAGE, MUSIC_LOOP_MZ, 12500)
 			break
 			
 		case TRACK_INVINCIBLE
-			SetMusicTrack("Marble.ogg", TRACK_STAGE, 99380)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528, 12500)
+			SetMusicTrack("Marble.ogg", TRACK_STAGE, MUSIC_LOOP_MZ)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
-			SetMusicTrack("Marble.ogg", TRACK_STAGE, 99380)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528)
+			SetMusicTrack("Marble.ogg", TRACK_STAGE, MUSIC_LOOP_MZ)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -578,7 +585,7 @@ end event
 event ObjectStartup
 
 	// Set the music track for this Stage
-	SetMusicTrack("Marble.ogg", TRACK_STAGE, 99380)
+	SetMusicTrack("Marble.ogg", TRACK_STAGE, MUSIC_LOOP_MZ)
 	SpeedUpMusic = MZSetup_SpeedUpMusic
 	SlowDownMusic = MZSetup_SpeedUpMusic
 

--- a/Sonic 1/Scripts/Players/PlayerObject.txt
+++ b/Sonic 1/Scripts/Players/PlayerObject.txt
@@ -117,8 +117,8 @@ private alias object.right	 	: player.right
 // Object values
 private alias object.value0  : player.rings
 private alias object.value1  : player.timer
-private alias object.value2  : player.abilityTimer			// Note: Also used by death/drowning state, not just character abilities
-private alias object.value3  : player.drownTimer			// Countdown before player moves to next drown "level"
+private alias object.value2  : player.abilityTimer
+private alias object.value3  : player.drownTimer			// Drowning values are progressed in the Water script, rather than here
 private alias object.value4  : player.drownLevel
 private alias object.value5  : player.customRollAnimSpeed
 private alias object.value6  : player.speedShoesTimer
@@ -126,12 +126,12 @@ private alias object.value7  : player.invincibleTimer
 private alias object.value8  : player.blinkTimer
 private alias object.value9  : player.skidSpeed
 private alias object.value10 : player.animationReserve		// Used by springs to store what animation will play after the bounce animation
-private alias object.value11 : player.scrollDelay			// A timer of how long the camera will stay locked for
-private alias object.value12 : player.tailFrame				// One of Tails' tail values
+private alias object.value11 : player.scrollDelay			// A timer of how long the camera will stay locked for, after a spindash
+private alias object.value12 : player.tailFrame				// One of Tails' tail values, not used by the player itself
 private alias object.value13 : player.tailAnim				// Also one of Tails' tail values
 private alias object.value14 : player.skidding
 // value15 is unused
-private alias object.value16 : player.isSidekick			// 0/false is player 1, 1/true if player 2
+private alias object.value16 : player.isSidekick			// false if player 1, true if player 2
 private alias object.value17 : debugMode.currentSelection
 private alias object.value18 : player.sortedDrawOrder
 private alias object.value19 : player.scoreBonus	// How many enemies the player has bounced on in a row
@@ -151,7 +151,7 @@ private alias object.value32 : player.jumpAbility			// Used to store whatever fu
 private alias object.value33 : player.spindashFunction		// Used to store whatever function this player has for its spindash ability
 private alias object.value34 : player.collisionDisabled
 private alias object.value35 : player.jumpAbilityState
-private alias object.value36 : player.flyCarryTimer		// Tails assist lockout timer
+private alias object.value36 : player.flyCarryTimer			// Tails assist lockout timer
 private alias object.value37 : player.shield				// Current shield the player has, see above constants for what is what
 private alias object.value40 : player.hitboxLeft
 private alias object.value38 : player.hitboxTop
@@ -166,7 +166,7 @@ private alias object.value45 : player.autoJumpTimer
 private alias object.value46 : player.targetLeaderPos.x
 private alias object.value47 : player.targetLeaderPos.y
 
-// Death Event related values
+// Death Event values
 private alias object.drawOrder 	: deathEvent.drawOrder
 private alias object.state 		: deathEvent.state
 private alias object.value1 	: deathEvent.leftTextPos
@@ -4243,7 +4243,7 @@ event ObjectMain
 			player.blinkTimer 		= 0
 			player.visible 			= true
 			player.abilityTimer 	= 0
-			player.drownTimer 	= 0
+			player.drownTimer 		= 0
 			player.drownLevel 		= 0
 			player.frame 			= debugMode.currentSelection
 			screen.cameraEnabled 	= true

--- a/Sonic 1/Scripts/Players/TailsObject.txt
+++ b/Sonic 1/Scripts/Players/TailsObject.txt
@@ -251,7 +251,7 @@ event ObjectDraw
 		break
 		
 	case 7 // ANI_SKIDDING
-	case 8 // ANI_SPINDASH
+	case 9 // ANI_SPINDASH
 		temp0 = player.tailFrame
 		temp0 >>= 2
 		temp0 += 11
@@ -359,7 +359,7 @@ event ObjectDraw
 	end switch
 	
 	// Draw Tails himself
-	// (Separate tails are drawn in the process above)
+	// (His separate tails are drawn in the process above, notably done before this function call since Tails is supposed to be ontop of his Tails)
 	DrawObjectAnimation()
 end event
 

--- a/Sonic 1/Scripts/SBZ/SBZSetup.txt
+++ b/Sonic 1/Scripts/SBZ/SBZSetup.txt
@@ -60,6 +60,15 @@ private alias object.collisionLeft : player.collisionLeft
 private alias object.collisionRight : player.collisionRight
 private alias object.collisionBottom : player.collisionBottom
 
+// Music Loops
+private alias 1     : MUSIC_LOOP_SBZ
+private alias 1     : MUSIC_LOOP_SBZ_F
+
+private alias 84680 : MUSIC_LOOP_FINAL
+
+private alias 39528 : MUSIC_LOOP_INV
+private alias 30436 : MUSIC_LOOP_INV_F
+
 
 // ========================
 // Function Declarations
@@ -307,13 +316,13 @@ function SBZSetup_SpeedUpMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436)
-			SwapMusicTrack("ScrapBrain_F.ogg", TRACK_STAGE, true, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("ScrapBrain_F.ogg", TRACK_STAGE, MUSIC_LOOP_SBZ_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("ScrapBrain_F.ogg", TRACK_STAGE, true)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436, 8000)
+			SetMusicTrack("ScrapBrain_F.ogg", TRACK_STAGE, MUSIC_LOOP_SBZ_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		// While other stage setups have a `case TRACK_BOSS` here, SBZ doesn't need it because the boss music never plays there
@@ -334,13 +343,13 @@ function SBZSetup_SlowDownMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528)
-			SwapMusicTrack("ScrapBrain.ogg", TRACK_STAGE, true, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("ScrapBrain.ogg", TRACK_STAGE, MUSIC_LOOP_SBZ, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("ScrapBrain.ogg", TRACK_STAGE, true)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528, 12500)
+			SetMusicTrack("ScrapBrain.ogg", TRACK_STAGE, MUSIC_LOOP_SBZ)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		// While other stage setups have a `case TRACK_BOSS` here, SBZ doesn't need it because the boss music never plays here
@@ -405,21 +414,21 @@ end event
 event ObjectStartup
 	if stage.actNum < 5
 		// If in acts 1-4, then play the SBZ music
-		SetMusicTrack("ScrapBrain.ogg", TRACK_STAGE, true)
+		SetMusicTrack("ScrapBrain.ogg", TRACK_STAGE, MUSIC_LOOP_SBZ)
 		SpeedUpMusic = SBZSetup_SpeedUpMusic
 		SlowDownMusic = SBZSetup_SlowDownMusic
 	else
 		// Act 5, play the Final Zone music
-		SetMusicTrack("Final.ogg", TRACK_STAGE, 84680)
+		SetMusicTrack("Final.ogg", TRACK_STAGE, MUSIC_LOOP_FINAL)
 	end if
 
-	// Cucky and Pocky are the animals that appear in Scrab Brain
+	// Cucky and Pocky are the animals that appear in Scrap Brain
 	animalType1 = TypeName[Cucky]
 	animalType2 = TypeName[Pocky]
 
-	object[SLOT_ZONESETUP].type = TypeName[SBZ Setup]
-	object[SLOT_ZONESETUP].priority = PRIORITY_ACTIVE
-	object[SLOT_ZONESETUP].drawOrder = 0
+	object[SLOT_ZONESETUP].type 		= TypeName[SBZ Setup]
+	object[SLOT_ZONESETUP].priority 	= PRIORITY_ACTIVE
+	object[SLOT_ZONESETUP].drawOrder 	= 0
 
 	// Init aniTiles
 	Copy16x16Tile(592, 604)
@@ -434,9 +443,9 @@ event ObjectStartup
 	case 1
 		object[SLOT_ZONESETUP].processBG = SBZSetup_BGEffectsAct1
 		break
-
 	case 2
 	case 5
+		// Act 5 is Final Zone
 		SetPaletteEntry(0, 172, 0xC0E0E0)
 		SetPaletteEntry(0, 173, 0x60A0A0)
 		SetPaletteEntry(0, 174, 0x006060)

--- a/Sonic 1/Scripts/SLZ/SLZSetup.txt
+++ b/Sonic 1/Scripts/SLZ/SLZSetup.txt
@@ -12,6 +12,14 @@ private alias object.value0 : object.paletteTimer
 private alias object.value1 : object.paletteIndex
 private alias object.value2 : object.scrollPos
 
+// Music Loops
+private alias 84364 : MUSIC_LOOP_SLZ
+private alias 67640 : MUSIC_LOOP_SLZ_F
+
+private alias 39528 : MUSIC_LOOP_INV
+private alias 30436 : MUSIC_LOOP_INV_F
+
+
 // ========================
 // Function Declarations
 // ========================
@@ -92,18 +100,18 @@ function SLZSetup_SpeedUpMusic
 	if temp0 == 0
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436)
-			SwapMusicTrack("Starlight_F.ogg", TRACK_STAGE, 67640, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("Starlight_F.ogg", TRACK_STAGE, MUSIC_LOOP_SLZ_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("Starlight_F.ogg", TRACK_STAGE, 67640)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436, 8000)
+			SetMusicTrack("Starlight_F.ogg", TRACK_STAGE, MUSIC_LOOP_SLZ_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
-			SetMusicTrack("Starlight_F.ogg", TRACK_STAGE, 67640)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436)
+			SetMusicTrack("Starlight_F.ogg", TRACK_STAGE, MUSIC_LOOP_SLZ_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -123,18 +131,18 @@ function SLZSetup_SlowDownMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528)
-			SwapMusicTrack("Starlight.ogg", TRACK_STAGE, 84364, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("Starlight.ogg", TRACK_STAGE, MUSIC_LOOP_SLZ, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("Starlight.ogg", TRACK_STAGE, 84364)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528, 12500)
+			SetMusicTrack("Starlight.ogg", TRACK_STAGE, MUSIC_LOOP_SLZ)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
-			SetMusicTrack("Starlight.ogg", TRACK_STAGE, 84364)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528)
+			SetMusicTrack("Starlight.ogg", TRACK_STAGE, MUSIC_LOOP_SLZ)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -190,7 +198,7 @@ end event
 event ObjectStartup
 	LoadSpriteSheet("SLZ/Objects.gif")
 	
-	SetMusicTrack("Starlight.ogg", TRACK_STAGE, 84364)
+	SetMusicTrack("Starlight.ogg", TRACK_STAGE, MUSIC_LOOP_SLZ)
 	SpeedUpMusic = SLZSetup_SpeedUpMusic
 	SlowDownMusic = SLZSetup_SlowDownMusic
 	

--- a/Sonic 1/Scripts/SYZ/SYZSetup.txt
+++ b/Sonic 1/Scripts/SYZ/SYZSetup.txt
@@ -49,6 +49,14 @@ private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
 
+// Music Loops
+private alias 101364 : MUSIC_LOOP_SYZ // This is 100712 on the level select...
+private alias 81128  : MUSIC_LOOP_SYZ_F
+
+private alias 39528  : MUSIC_LOOP_INV
+private alias 30436  : MUSIC_LOOP_INV_F
+
+
 // ========================
 // Tables
 // ========================
@@ -414,18 +422,18 @@ function SYZSetup_SpeedUpMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436)
-			SwapMusicTrack("SpringYard_F.ogg", TRACK_STAGE, 81128, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("SpringYard_F.ogg", TRACK_STAGE, MUSIC_LOOP_SYZ_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("SpringYard_F.ogg", TRACK_STAGE, 81128)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436, 8000)
+			SetMusicTrack("SpringYard_F.ogg", TRACK_STAGE, MUSIC_LOOP_SYZ_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
-			SetMusicTrack("SpringYard_F.ogg", TRACK_STAGE, 81128)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30436)
+			SetMusicTrack("SpringYard_F.ogg", TRACK_STAGE, MUSIC_LOOP_SYZ_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -444,18 +452,18 @@ function SYZSetup_SlowDownMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528)
-			SwapMusicTrack("SpringYard.ogg", TRACK_STAGE, 101364, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("SpringYard.ogg", TRACK_STAGE, MUSIC_LOOP_SYZ, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("SpringYard.ogg", TRACK_STAGE, 101364)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528, 12500)
+			SetMusicTrack("SpringYard.ogg", TRACK_STAGE, MUSIC_LOOP_SYZ)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
-			SetMusicTrack("SpringYard.ogg", TRACK_STAGE, 101364)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 39528)
+			SetMusicTrack("SpringYard.ogg", TRACK_STAGE, MUSIC_LOOP_SYZ)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -491,7 +499,7 @@ end event
 
 event ObjectStartup
 	// Set the music track
-	SetMusicTrack("SpringYard.ogg", TRACK_STAGE, 101364)
+	SetMusicTrack("SpringYard.ogg", TRACK_STAGE, MUSIC_LOOP_SYZ)
 
 	// Also set the speed up/slow down functions
 	SpeedUpMusic = SYZSetup_SpeedUpMusic
@@ -517,7 +525,7 @@ event ObjectStartup
 	object[SLOT_ZONESETUP].priority = PRIORITY_ACTIVE
 
 	SYZSetup_oscillation = 0
-	SYZSetup_RLightFrame = 0f
+	SYZSetup_RLightFrame = 0
 
 	if options.attractMode == true
 		switch stage.playerListPos

--- a/Sonic 2/Scripts/ARZ/ARZSetup.txt
+++ b/Sonic 2/Scripts/ARZ/ARZSetup.txt
@@ -32,7 +32,6 @@ private alias 10 : SLOT_ZONESETUP
 private alias 25 : SLOT_MUSICEVENT_CHANGE
 private alias 26 : SLOT_MUSICEVENT_BOSS
 
-
 // Music Events
 private alias  0 : MUSICEVENT_FADETOBOSS
 private alias  1 : MUSICEVENT_FADETOSTAGE
@@ -41,6 +40,14 @@ private alias  2 : MUSICEVENT_TRANSITION
 private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
+
+// Music Loops
+private alias 1     : MUSIC_LOOP_ARZ
+private alias 1     : MUSIC_LOOP_ARZ_F
+
+private alias 38679 : MUSIC_LOOP_INV
+private alias 30897 : MUSIC_LOOP_INV_F
+
 
 // ========================
 // Function Declarations
@@ -795,20 +802,20 @@ function ARZSetup_SpeedUpMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("AquaticRuin_F.ogg", TRACK_STAGE, true, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("AquaticRuin_F.ogg", TRACK_STAGE, MUSIC_LOOP_ARZ_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("AquaticRuin_F.ogg", TRACK_STAGE, true)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("AquaticRuin_F.ogg", TRACK_STAGE, MUSIC_LOOP_ARZ_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("AquaticRuin_F.ogg", TRACK_STAGE, true)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("AquaticRuin_F.ogg", TRACK_STAGE, MUSIC_LOOP_ARZ_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -827,20 +834,20 @@ function ARZSetup_SlowDownMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("AquaticRuin.ogg", TRACK_STAGE, true, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("AquaticRuin.ogg", TRACK_STAGE, MUSIC_LOOP_ARZ, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("AquaticRuin.ogg", TRACK_STAGE, true)
-			SwapMusicTrack("Invincibility.ogg", 2, 38679, 12500)
+			SetMusicTrack("AquaticRuin.ogg", TRACK_STAGE, MUSIC_LOOP_ARZ)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("AquaticRuin.ogg", TRACK_STAGE, true)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("AquaticRuin.ogg", TRACK_STAGE, MUSIC_LOOP_ARZ)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -895,7 +902,7 @@ event ObjectStartup
 	// Reset the boss flash colour to be pure black
 	SetPaletteEntry(0, 192, 0x000000)
 
-	SetMusicTrack("AquaticRuin.ogg", TRACK_STAGE, true)
+	SetMusicTrack("AquaticRuin.ogg", TRACK_STAGE, MUSIC_LOOP_ARZ)
 
 	SpeedUpMusic = ARZSetup_SpeedUpMusic
 	SlowDownMusic = ARZSetup_SlowDownMusic

--- a/Sonic 2/Scripts/ARZ/ARZSetup.txt
+++ b/Sonic 2/Scripts/ARZ/ARZSetup.txt
@@ -62,10 +62,10 @@ reserve function ARZSetup_SlowDownMusic
 // ========================
 // Static Values
 // ========================
-public value Water_flashTimer = 0  // Uses "Water_" since all water objects use it from the setup so its easier to make new objs this way
+public value ARZSetup_value33 = 0 
 
-// Kept here for mod compatability reasons, please don't use this if possible
-private alias Water_flashTimer : ARZSetup_value33
+// Uses "Water_" since all water objects use it from the setup so its easier to make new objs this way
+private alias ARZSetup_value33 : Water_flashTimer
 
 // ========================
 // Tables

--- a/Sonic 2/Scripts/ARZ/Water.txt
+++ b/Sonic 2/Scripts/ARZ/Water.txt
@@ -82,7 +82,7 @@ private value Water_waterSlotID  = 0
 private value Water_activateFlag = false
 
 // Kept here for mod compatability reasons, please don't use this if possible
-private alias Water_flashTimer : ARZSetup_value33
+private alias ARZSetup_value33 : Water_flashTimer
 
 // ========================
 // Tables

--- a/Sonic 2/Scripts/CNZ/CNZSetup.txt
+++ b/Sonic 2/Scripts/CNZ/CNZSetup.txt
@@ -61,12 +61,16 @@ private alias 30897  : MUSIC_LOOP_INV_F
 // ========================
 // Function Declarations
 // ========================
-reserve function CNZSetup_TubeSwitch_Ground
-reserve function CNZSetup_TubeSwitch_Air
+reserve function CNZSetup_Function97
+reserve function CNZSetup_Function98
 reserve function CNZSetup_SpeedUpMusic1P
 reserve function CNZSetup_SlowDownMusic1P
 reserve function CNZSetup_SpeedUpMusic2P
 reserve function CNZSetup_SlowDownMusic2P
+
+// Has to be declared under an old name then aliases for old mod compatability reasons...
+private alias CNZSetup_Function97 : CNZSetup_TubeSwitch_Ground
+private alias CNZSetup_Function98 : CNZSetup_TubeSwitch_Air
 
 // ========================
 // Tables

--- a/Sonic 2/Scripts/CNZ/CNZSetup.txt
+++ b/Sonic 2/Scripts/CNZ/CNZSetup.txt
@@ -38,7 +38,6 @@ private alias 10 : SLOT_ZONESETUP
 private alias 25 : SLOT_MUSICEVENT_CHANGE
 private alias 26 : SLOT_MUSICEVENT_BOSS
 
-
 // Music Events
 private alias  0 : MUSICEVENT_FADETOBOSS
 private alias  1 : MUSICEVENT_FADETOSTAGE
@@ -47,6 +46,17 @@ private alias  2 : MUSICEVENT_TRANSITION
 private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
+
+// Music Loops
+private alias 62820  : MUSIC_LOOP_CNZ_1P
+private alias 50312  : MUSIC_LOOP_CNZ_1P_F
+
+private alias 95868  : MUSIC_LOOP_CNZ_2P
+private alias 76718  : MUSIC_LOOP_CNZ_2P_F
+
+private alias 38679  : MUSIC_LOOP_INV
+private alias 30897  : MUSIC_LOOP_INV_F
+
 
 // ========================
 // Function Declarations
@@ -638,20 +648,20 @@ function CNZSetup_SpeedUpMusic1P
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("CasinoNight_F.ogg", TRACK_STAGE, 50312, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("CasinoNight_F.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_1P_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("CasinoNight_F.ogg", TRACK_STAGE, 50312)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("CasinoNight_F.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_1P_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("CasinoNight_F.ogg", TRACK_STAGE, 50312)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("CasinoNight_F.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_1P_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -670,20 +680,20 @@ function CNZSetup_SlowDownMusic1P
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("CasinoNight.ogg", TRACK_STAGE, 62820, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("CasinoNight.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_1P, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("CasinoNight.ogg", TRACK_STAGE, 62820)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679, 12500)
+			SetMusicTrack("CasinoNight.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_1P)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("CasinoNight.ogg", TRACK_STAGE, 62820)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("CasinoNight.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_1P)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -702,20 +712,20 @@ function CNZSetup_SpeedUpMusic2P
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("CasinoNight2_F.ogg", TRACK_STAGE, 76718, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("CasinoNight2_F.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_2P_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("CasinoNight2_F.ogg", TRACK_STAGE, 76718)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("CasinoNight2_F.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_2P_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("CasinoNight2_F.ogg", TRACK_STAGE, 76718)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("CasinoNight2_F.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_2P_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -734,20 +744,20 @@ function CNZSetup_SlowDownMusic2P
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("CasinoNight2.ogg", TRACK_STAGE, 95868, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("CasinoNight2.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_2P, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("CasinoNight2.ogg", TRACK_STAGE, 95868)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679, 12500)
+			SetMusicTrack("CasinoNight2.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_2P)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("CasinoNight2.ogg", TRACK_STAGE, 95868)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("CasinoNight2.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_2P)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -846,11 +856,11 @@ end event
 
 event ObjectStartup
 	if options.vsMode == false
-		SetMusicTrack("CasinoNight.ogg", TRACK_STAGE, 62820)
+		SetMusicTrack("CasinoNight.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_1P)
 		SpeedUpMusic = CNZSetup_SpeedUpMusic1P
 		SlowDownMusic = CNZSetup_SlowDownMusic1P
 	else
-		SetMusicTrack("CasinoNight2.ogg", TRACK_STAGE, 95868)
+		SetMusicTrack("CasinoNight2.ogg", TRACK_STAGE, MUSIC_LOOP_CNZ_2P)
 		SpeedUpMusic = CNZSetup_SpeedUpMusic2P
 		SlowDownMusic = CNZSetup_SlowDownMusic2P
 	end if

--- a/Sonic 2/Scripts/CNZ/DPlunger.txt
+++ b/Sonic 2/Scripts/CNZ/DPlunger.txt
@@ -26,6 +26,8 @@ private alias object.jumpHold : player.jumpHold
 
 private alias object.value1  : player.timer
 
+private alias CNZSetup_Function97 : CNZSetup_TubeSwitch_Ground
+
 // ========================
 // Function Declarations
 // ========================

--- a/Sonic 2/Scripts/CNZ/Spinner_H.txt
+++ b/Sonic 2/Scripts/CNZ/Spinner_H.txt
@@ -20,6 +20,14 @@ private alias object.animation : player.animation
 private alias object.value34 : player.collisionDisabled
 private alias object.value35 : player.jumpAbilityState
 
+private alias CNZSetup_Function97 : CNZSetup_TubeSwitch_Ground
+private alias CNZSetup_Function98 : CNZSetup_TubeSwitch_Air
+
+
+// ========================
+// Events
+// ========================
+
 event ObjectMain
 	foreach (GROUP_PLAYERS, currentPlayer, ACTIVE_ENTITIES)
 		CheckEqual(player[currentPlayer].state, PlayerObject_Death)

--- a/Sonic 2/Scripts/CNZ/Spinner_V.txt
+++ b/Sonic 2/Scripts/CNZ/Spinner_V.txt
@@ -22,6 +22,14 @@ private alias object.animation : player.animation
 private alias object.value34 : player.collisionDisabled
 private alias object.value35 : player.jumpAbilityState
 
+private alias CNZSetup_Function97 : CNZSetup_TubeSwitch_Ground
+private alias CNZSetup_Function98 : CNZSetup_TubeSwitch_Air
+
+
+// ========================
+// Events
+// ========================
+
 event ObjectMain
 	foreach (GROUP_PLAYERS, currentPlayer, ACTIVE_ENTITIES)
 		if player[currentPlayer].collisionDisabled == true

--- a/Sonic 2/Scripts/CPZ/CPZSetup.txt
+++ b/Sonic 2/Scripts/CPZ/CPZSetup.txt
@@ -9,11 +9,10 @@
 // Aliases
 // ========================
 private alias object.value0  : object.aniTileTimer
-// value1 is unused
+// value1 is unused?
 private alias object.value2 : object.scrollPos
 
-// Jump in values here for some reason...
-// TODO: actually it seems like the values got mixed up when aliasing, these _should_ be used
+// TODO: these values got mixed up when aliasing it seems, fix them
 
 // Values used for updating the underwater Super Palette
 private alias object.value6  : object.clrDivisor_R
@@ -55,6 +54,14 @@ private alias  2 : MUSICEVENT_TRANSITION
 private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
+
+// Music Loops
+private alias 684580 : MUSIC_LOOP_CPZ
+private alias 547578 : MUSIC_LOOP_CPZ_F
+
+private alias 38679  : MUSIC_LOOP_INV
+private alias 30897  : MUSIC_LOOP_INV_F
+
 
 // ========================
 // Function Declarations
@@ -716,20 +723,20 @@ function CPZSetup_SpeedUpMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("ChemicalPlant_F.ogg", TRACK_STAGE, 547578, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("ChemicalPlant_F.ogg", TRACK_STAGE, MUSIC_LOOP_CPZ_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("ChemicalPlant_F.ogg", TRACK_STAGE, 547578)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("ChemicalPlant_F.ogg", TRACK_STAGE, MUSIC_LOOP_CPZ_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("ChemicalPlant_F.ogg", TRACK_STAGE, 547578)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("ChemicalPlant_F.ogg", TRACK_STAGE, MUSIC_LOOP_CPZ_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -748,20 +755,20 @@ function CPZSetup_SlowDownMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("ChemicalPlant.ogg", TRACK_STAGE, 684580, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("ChemicalPlant.ogg", TRACK_STAGE, MUSIC_LOOP_CPZ, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("ChemicalPlant.ogg", TRACK_STAGE, 684580)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679, 12500)
+			SetMusicTrack("ChemicalPlant.ogg", TRACK_STAGE, MUSIC_LOOP_CPZ)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("ChemicalPlant.ogg", TRACK_STAGE, 684580)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("ChemicalPlant.ogg", TRACK_STAGE, MUSIC_LOOP_CPZ)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -896,7 +903,7 @@ event ObjectStartup
 	SetPaletteEntry(0, 192, 0x000000) // Set color index 192 to be black
 
 	// Set the Chemical Plant music, and set its speedup/slowndown functions too
-	SetMusicTrack("ChemicalPlant.ogg", TRACK_STAGE, 684580)
+	SetMusicTrack("ChemicalPlant.ogg", TRACK_STAGE, MUSIC_LOOP_CPZ)
 	SpeedUpMusic = CPZSetup_SpeedUpMusic
 	SlowDownMusic = CPZSetup_SlowDownMusic
 
@@ -938,6 +945,7 @@ event ObjectStartup
 
 	Water_flashTimer = 0
 
+	// Reset the ripple effect
 	arrayPos0 = 0
 	while arrayPos0 < 576
 		temp0 = arrayPos0

--- a/Sonic 2/Scripts/DEZ/DEZSetup.txt
+++ b/Sonic 2/Scripts/DEZ/DEZSetup.txt
@@ -22,6 +22,10 @@ private alias 10 : SLOT_ZONESETUP
 // Tracks
 private alias 0 : TRACK_STAGE
 
+// Music Loops
+private alias 1 : MUSIC_LOOP_DEZ
+
+
 // ========================
 // Tables
 // ========================
@@ -111,7 +115,7 @@ end event
 
 event ObjectStartup
 	// Set the stage music
-	SetMusicTrack("DeathEgg.ogg", TRACK_STAGE, true)
+	SetMusicTrack("DeathEgg.ogg", TRACK_STAGE, MUSIC_LOOP_DEZ)
 
 	// No speed up/slow down variants need to be set since Speed Shoes shouldn't exist in DEZ at all
 

--- a/Sonic 2/Scripts/EHZ/EHZSetup.txt
+++ b/Sonic 2/Scripts/EHZ/EHZSetup.txt
@@ -46,7 +46,6 @@ private alias 10 : SLOT_ZONESETUP
 private alias 25 : SLOT_MUSICEVENT_CHANGE
 private alias 26 : SLOT_MUSICEVENT_BOSS
 
-
 // Music Events
 private alias  0 : MUSICEVENT_FADETOBOSS
 private alias  1 : MUSICEVENT_FADETOSTAGE
@@ -55,6 +54,17 @@ private alias  2 : MUSICEVENT_TRANSITION
 private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
+
+// Music Loops
+private alias 152750 : MUSIC_LOOP_EHZ_1P
+private alias 122240 : MUSIC_LOOP_EHZ_1P_F
+
+private alias 99572  : MUSIC_LOOP_EHZ_2P
+private alias 79604  : MUSIC_LOOP_EHZ_2P_F
+
+private alias 38679  : MUSIC_LOOP_INV
+private alias 30897  : MUSIC_LOOP_INV_F
+
 
 // ========================
 // Function Declarations
@@ -68,6 +78,7 @@ reserve function EHZSetup_SlowDownMusic2P
 // Static Values
 // ========================
 private value EHZSetup_hasAchievement = false
+
 
 // ========================
 // Tables
@@ -401,20 +412,20 @@ function EHZSetup_SpeedUpMusic1P
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("EmeraldHill_F.ogg", TRACK_STAGE, 122240, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("EmeraldHill_F.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_1P_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("EmeraldHill_F.ogg", TRACK_STAGE, 122240)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("EmeraldHill_F.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_1P_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("EmeraldHill_F.ogg", TRACK_STAGE, 122240)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("EmeraldHill_F.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_1P_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -434,20 +445,20 @@ function EHZSetup_SlowDownMusic1P
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("EmeraldHill.ogg", TRACK_STAGE, 152750, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("EmeraldHill.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_1P, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("EmeraldHill.ogg", TRACK_STAGE, 152750)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679, 12500)
+			SetMusicTrack("EmeraldHill.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_1P)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("EmeraldHill.ogg", TRACK_STAGE, 152750)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("EmeraldHill.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_1P)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -467,20 +478,20 @@ function EHZSetup_SpeedUpMusic2P
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("EmeraldHill2_F.ogg", TRACK_STAGE, 79604, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("EmeraldHill2_F.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_2P_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("EmeraldHill2_F.ogg", TRACK_STAGE, 79604)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("EmeraldHill2_F.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_2P_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("EmeraldHill2_F.ogg", TRACK_STAGE, 79604)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("EmeraldHill2_F.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_2P_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -499,20 +510,20 @@ function EHZSetup_SlowDownMusic2P
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("EmeraldHill2.ogg", TRACK_STAGE, 99572, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("EmeraldHill2.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_2P, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("EmeraldHill2.ogg", TRACK_STAGE, 99572)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679, 12500)
+			SetMusicTrack("EmeraldHill2.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_2P)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("EmeraldHill2.ogg", TRACK_STAGE, 99572)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("EmeraldHill2.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_2P)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -632,14 +643,15 @@ event ObjectMain
 			if specialStage.emeralds >= 0b01111111
 				if options.gameMode == MODE_NOSAVE
 					EHZSetup_hasAchievement = true
-					CallNativeFunction2(SetAchievement, AchievementName[Early Bird Special], 100) // Get all emeralds in Emerald Hill achievment
+					// Get all emeralds in Emerald Hill achievment
+					CallNativeFunction2(SetAchievement, AchievementName[Early Bird Special], 100)
 				end if
 
 				if options.gameMode == MODE_NORMAL
 					arrayPos1 = options.saveSlot
 					arrayPos1 <<= 3
 					arrayPos1 += 4
-					if saveRAM[arrayPos1] < 20 // make sure our save file hasn't been completed, you have to play by the rules and do it on the first go!
+					if saveRAM[arrayPos1] < 20 // Make sure our save file hasn't been completed, you have to play by the rules and do it on the first go!
 						EHZSetup_hasAchievement = true
 						CallNativeFunction2(SetAchievement, AchievementName[Early Bird Special], 100)
 					end if
@@ -652,22 +664,26 @@ end event
 
 event ObjectStartup
 	if stage.activeList != BONUS_STAGE
+		// Different music based on the current mode
+		// To accommodate the different music, there are also separate speedup and slowdown functions for each track
+
 		if options.vsMode == false
-			SetMusicTrack("EmeraldHill.ogg", TRACK_STAGE, 152750)
+			SetMusicTrack("EmeraldHill.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_1P)
 			SpeedUpMusic = EHZSetup_SpeedUpMusic1P
 			SlowDownMusic = EHZSetup_SlowDownMusic1P
 		else
-			SetMusicTrack("EmeraldHill2.ogg", TRACK_STAGE, 99572)
+			SetMusicTrack("EmeraldHill2.ogg", TRACK_STAGE, MUSIC_LOOP_EHZ_2P)
 			SpeedUpMusic = EHZSetup_SpeedUpMusic2P
 			SlowDownMusic = EHZSetup_SlowDownMusic2P
 		end if
 	else
-		// Boss Attack Stage, play DEZ track
+		// In the Boss Attack version of the state, play the DEZ track instead
 		SetMusicTrack("DeathEgg.ogg", TRACK_STAGE, true)
 	end if
 
 	animalType1 = TypeName[Flicky]
 	animalType2 = TypeName[Ricky]
+	
 	tileLayer[1].scrollPos = -0x80000
 
 	arrayPos0 = 0
@@ -681,7 +697,8 @@ event ObjectStartup
 	object[SLOT_ZONESETUP].type = TypeName[EHZ Setup]
 	object[SLOT_ZONESETUP].priority = PRIORITY_ACTIVE
 
-	SetPaletteEntry(0, 192, 0x000000) // boss flash colour
+	// Reset the boss flash colour
+	SetPaletteEntry(0, 192, 0x000000)
 
 	if options.attractMode == true
 		switch stage.playerListPos

--- a/Sonic 2/Scripts/HPZ/HPZSetup.txt
+++ b/Sonic 2/Scripts/HPZ/HPZSetup.txt
@@ -62,6 +62,22 @@ private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
 
+// Music Loops
+
+// There's something weird about the normal stage song's loop point:
+//  - The initial setup for this stage uses 18671
+//    - This is what the Sound Test uses as well
+//  - However, the loop point set when slowing down the tracks is 18672
+//  - This may just be a one sample difference but I assure you, it's quite important because now it makes everything more complicated
+//  - Here, I've just decided to label the speed-up version as the proper one, I do hope you'll understand...
+private alias 18672 : MUSIC_LOOP_MCZ_2P
+private alias 15272 : MUSIC_LOOP_MCZ_2P_F
+
+private alias 59852 : MUSIC_LOOP_PPZ
+
+private alias 38679 : MUSIC_LOOP_INV
+private alias 30897 : MUSIC_LOOP_INV_F
+
 
 // ========================
 // Function Declarations
@@ -474,20 +490,20 @@ function HPZSetup_SpeedUpMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("MysticCave2_F.ogg", TRACK_STAGE, 15272, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("MysticCave2_F.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("MysticCave2_F.ogg", TRACK_STAGE, 15272)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("MysticCave2_F.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("MysticCave2_F.ogg", TRACK_STAGE, 15272)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("MysticCave2_F.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -507,20 +523,20 @@ function HPZSetup_SlowDownMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("MysticCave2.ogg", TRACK_STAGE, 18672, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("MysticCave2.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("MysticCave2.ogg", TRACK_STAGE, 18672)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679, 12500)
+			SetMusicTrack("MysticCave2.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("MysticCave2.ogg", TRACK_STAGE, 18672)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("MysticCave2.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -770,12 +786,12 @@ end event
 event ObjectStartup
 	if stage.actNum == 1
 		// Normal Hidden Palace Zone
-		SetMusicTrack("MysticCave2.ogg", TRACK_STAGE, 18671) // why is this one 1 sample less than the loopPoint found in HPZSetup_SlowDownMusic...?
+		SetMusicTrack("MysticCave2.ogg", TRACK_STAGE, 18671) // see note up top as for why MUSIC_LOOP_MCZ_2P isn't being used here
 		SpeedUpMusic = HPZSetup_SpeedUpMusic
 		SlowDownMusic = HPZSetup_SlowDownMusic
 	else
 		// Proto Palace Zone
-		SetMusicTrack("Extra.ogg", TRACK_STAGE, 59852)
+		SetMusicTrack("Extra.ogg", TRACK_STAGE, MUSIC_LOOP_PPZ)
 	end if
 
 	if stage.player2Enabled == true

--- a/Sonic 2/Scripts/HTZ/HTZSetup.txt
+++ b/Sonic 2/Scripts/HTZ/HTZSetup.txt
@@ -75,11 +75,20 @@ private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
 
+// Music Loops
+private alias 1     : MUSIC_LOOP_HTZ
+private alias 1     : MUSIC_LOOP_HTZ_F
+
+private alias 38679 : MUSIC_LOOP_INV
+private alias 30897 : MUSIC_LOOP_INV_F
+
+
 // ========================
 // Function Declarations
 // ========================
 reserve function HTZSetup_SpeedUpMusic
 reserve function HTZSetup_SlowDownMusic
+
 
 // ========================
 // Static Values
@@ -137,20 +146,20 @@ function HTZSetup_SpeedUpMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("HillTop_F.ogg", TRACK_STAGE, true, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("HillTop_F.ogg", TRACK_STAGE, MUSIC_LOOP_HTZ_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("HillTop_F.ogg", TRACK_STAGE, true)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("HillTop_F.ogg", TRACK_STAGE, MUSIC_LOOP_HTZ_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_GAMEOVER
 		case TRACK_SUPER
-			SetMusicTrack("HillTop_F.ogg", TRACK_STAGE, true)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("HillTop_F.ogg", TRACK_STAGE, MUSIC_LOOP_HTZ_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -169,20 +178,20 @@ function HTZSetup_SlowDownMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("HillTop.ogg", TRACK_STAGE, true, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("HillTop.ogg", TRACK_STAGE, MUSIC_LOOP_HTZ, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("HillTop.ogg", TRACK_STAGE, true)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679, 12500)
+			SetMusicTrack("HillTop.ogg", TRACK_STAGE, MUSIC_LOOP_HTZ)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_GAMEOVER
 		case TRACK_SUPER
-			SetMusicTrack("HillTop.ogg", TRACK_STAGE, true)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("HillTop.ogg", TRACK_STAGE, MUSIC_LOOP_HTZ)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -420,7 +429,7 @@ end event
 
 
 event ObjectStartup
-	SetMusicTrack("HillTop.ogg", TRACK_STAGE, true)
+	SetMusicTrack("HillTop.ogg", TRACK_STAGE, MUSIC_LOOP_HTZ)
 
 	// Set the music speed-changing functions
 	SpeedUpMusic = HTZSetup_SpeedUpMusic

--- a/Sonic 2/Scripts/LevelSelect/BGAnimation.txt
+++ b/Sonic 2/Scripts/LevelSelect/BGAnimation.txt
@@ -9,15 +9,14 @@
 // Aliases
 // ========================
 private alias object.value0 	   : object.timer
-private alias object.propertyValue : object.enabled
+private alias object.propertyValue : object.hide
 
 // ========================
 // Static Values
 // ========================
-public value BGAnimation_currentPreview = 0
+public value BGAnimation_value0 = 0
 
-// Kept here for mod compatability reasons, please don't use this if possible
-private alias BGAnimation_currentPreview : BGAnimation_value0
+private alias BGAnimation_value0 : BGAnimation_currentPreview
 
 event ObjectMain
 	object.timer++
@@ -41,7 +40,7 @@ end event
 
 
 event ObjectDraw
-	if object.enabled == false
+	if object.hide == false
 		// This script doesn't only do BG animation, it also deals with drawing the zone preview at the bottom right of the screen
 		// BGAnimation_currentPreview is set by the Menu Control object
 		temp0 = screen.xcenter
@@ -90,12 +89,40 @@ event ObjectStartup
 end event
 
 
+event RSDKEdit
+	if editor.returnVariable == true
+		switch editor.variableID
+		case EDIT_VAR_PROPVAL // property value
+			checkResult = object.propertyValue
+			break
+		case 0 // hidden
+			checkResult = object.propertyValue
+			break
+		end switch
+	else
+		switch editor.variableID
+		case EDIT_VAR_PROPVAL // property value
+			object.propertyValue = editor.variableValue
+			break
+		case 0 // hidden
+			object.propertyValue = editor.variableValue
+			break
+		end switch
+	end if
+end event
+
 event RSDKDraw
 	DrawSprite(0)
 end event
 
 
 event RSDKLoad
-	LoadSpriteSheet("Global/Display.gif")
-	SpriteFrame(-16, -16, 32, 32, 1, 143)
+	LoadSpriteSheet("LevelSelect/Icons.gif")
+	SpriteFrame(56, -12, 32, 24, 0, 50)
+	SpriteFrame(32, -24, 80, 50, 0, 0)
+
+	AddEditorVariable("hidden")
+	SetActiveVariable("hidden")
+	AddEnumVariable("false", false)
+	AddEnumVariable("true", true)
 end event

--- a/Sonic 2/Scripts/LevelSelect/ConfigScreen.txt
+++ b/Sonic 2/Scripts/LevelSelect/ConfigScreen.txt
@@ -56,7 +56,8 @@ private alias 3 : CONFIGSCREEN_SHIELD_RAND_S3
 
 // MenuControl aliases
 // Kept here for mod compatability reasons, please don't use this if possible
-private alias MenuControl_optionsMenuOpen : MenuControl_value2
+private alias MenuControl_value2 : MenuControl_optionsMenuOpen
+
 
 event ObjectMain
 	switch object.state

--- a/Sonic 2/Scripts/LevelSelect/MenuButton.txt
+++ b/Sonic 2/Scripts/LevelSelect/MenuButton.txt
@@ -14,7 +14,7 @@ private alias object.value1 : object.pressed
 private alias object.value3 : menuControl.currentSelection
 
 // Kept here for mod compatability reasons, please don't use this if possible
-private alias MenuControl_optionsMenuOpen : MenuControl_value2
+private alias MenuControl_value2 : MenuControl_optionsMenuOpen
 
 event ObjectMain
 	if MenuControl_optionsMenuOpen == false

--- a/Sonic 2/Scripts/LevelSelect/MenuControl.txt
+++ b/Sonic 2/Scripts/LevelSelect/MenuControl.txt
@@ -23,27 +23,52 @@ private alias 2 : MENUCONTROL_MAIN
 private alias 3 : MENUCONTROL_LOADLEVEL
 private alias 4 : MENUCONTROL_LOADSPECIAL
 
+// The maximum number of selections available
+private alias 22 : MAX_SELECTION_COUNT
+
+// Music Loops
+private alias 152750 : MUSIC_LOOP_EHZ_1P
+private alias 18671  : MUSIC_LOOP_MCZ_2P // This is 18672 in some other cases...
+private alias 293572 : MUSIC_LOOP_OOZ
+private alias 309378 : MUSIC_LOOP_MPZ
+private alias 1      : MUSIC_LOOP_HTZ
+private alias 1      : MUSIC_LOOP_ARZ
+private alias 95868  : MUSIC_LOOP_CNZ_2P
+private alias 62820  : MUSIC_LOOP_CNZ_1P
+private alias 1      : MUSIC_LOOP_DEZ
+private alias 99356  : MUSIC_LOOP_MCZ_1P
+private alias 99572  : MUSIC_LOOP_EHZ_2P
+private alias 198253 : MUSIC_LOOP_SCZ
+private alias 684580 : MUSIC_LOOP_CPZ
+private alias 99874  : MUSIC_LOOP_WFZ
+private alias 59852  : MUSIC_LOOP_PPZ
+private alias 496644 : MUSIC_LOOP_SPECIAL
+private alias 38679  : MUSIC_LOOP_INV
+
+
 // ========================
 // Function Declarations
 // ========================
 reserve function MenuControl_HandleSecrets
 reserve function MenuControl_SoundTestPlayer
 
+
 // ========================
 // Static Values
 // ========================
+public value MenuControl_value2 				= false
+
 private value MenuControl_optionsMenuCounter 	= 0
-public value MenuControl_optionsMenuOpen 		= false
 private value MenuControl_debugModeCounter 		= 0
 private value MenuControl_emeraldCodeCounter 	= 0
 private value MenuControl_continueCodeCounter 	= 0
 private value MenuControl_PPZCodeCounter 		= 0
 
 // Kept here for mod compatability reasons, please don't use this if possible
-private alias BGAnimation_currentPreview : BGAnimation_value0
+private alias BGAnimation_value0 : BGAnimation_currentPreview
 
 // Kept here for mod compatability reasons, please don't use this if possible
-private alias MenuControl_optionsMenuOpen : MenuControl_value2
+private alias MenuControl_value2 : MenuControl_optionsMenuOpen
 
 // ========================
 // Tables
@@ -221,77 +246,77 @@ function MenuControl_SoundTestPlayer
 			break
 
 		case 2
-			SetMusicTrack("EmeraldHill.ogg", 0, 152750)
+			SetMusicTrack("EmeraldHill.ogg", 0, MUSIC_LOOP_EHZ_1P)
 			PlayMusic(0)
 			break
 
 		case 3
-			SetMusicTrack("MysticCave2.ogg", 0, 18671)
+			SetMusicTrack("MysticCave2.ogg", 0, MUSIC_LOOP_MCZ_2P)
 			PlayMusic(0)
 			break
 
 		case 4
-			SetMusicTrack("OilOcean.ogg", 0, 293572)
+			SetMusicTrack("OilOcean.ogg", 0, MUSIC_LOOP_OOZ)
 			PlayMusic(0)
 			break
 
 		case 5
-			SetMusicTrack("Metropolis.ogg", 0, 309378)
+			SetMusicTrack("Metropolis.ogg", 0, MUSIC_LOOP_MPZ)
 			PlayMusic(0)
 			break
 
 		case 6
-			SetMusicTrack("HillTop.ogg", 0, true)
+			SetMusicTrack("HillTop.ogg", 0, MUSIC_LOOP_HTZ)
 			PlayMusic(0)
 			break
 
 		case 7
-			SetMusicTrack("AquaticRuin.ogg", 0, true)
+			SetMusicTrack("AquaticRuin.ogg", 0, MUSIC_LOOP_ARZ)
 			PlayMusic(0)
 			break
 
 		case 8
-			SetMusicTrack("CasinoNight2.ogg", 0, 95868)
+			SetMusicTrack("CasinoNight2.ogg", 0, MUSIC_LOOP_CNZ_2P)
 			PlayMusic(0)
 			break
 
 		case 9
-			SetMusicTrack("CasinoNight.ogg", 0, 62820)
+			SetMusicTrack("CasinoNight.ogg", 0, MUSIC_LOOP_CNZ_1P)
 			PlayMusic(0)
 			break
 
 		case 10
-			SetMusicTrack("DeathEgg.ogg", 0, true)
+			SetMusicTrack("DeathEgg.ogg", 0, MUSIC_LOOP_DEZ)
 			PlayMusic(0)
 			break
 
 		case 11
-			SetMusicTrack("MysticCave.ogg", 0, 99356)
+			SetMusicTrack("MysticCave.ogg", 0, MUSIC_LOOP_MCZ_1P)
 			PlayMusic(0)
 			break
 
 		case 12
-			SetMusicTrack("EmeraldHill2.ogg", 0, 99572)
+			SetMusicTrack("EmeraldHill2.ogg", 0, MUSIC_LOOP_EHZ_2P)
 			PlayMusic(0)
 			break
 
 		case 13
-			SetMusicTrack("SkyChase.ogg", 0, 198253)
+			SetMusicTrack("SkyChase.ogg", 0, MUSIC_LOOP_SCZ)
 			PlayMusic(0)
 			break
 
 		case 14
-			SetMusicTrack("ChemicalPlant.ogg", 0, 684580)
+			SetMusicTrack("ChemicalPlant.ogg", 0, MUSIC_LOOP_CPZ)
 			PlayMusic(0)
 			break
 
 		case 15
-			SetMusicTrack("WingFortress.ogg", 0, 99874)
+			SetMusicTrack("WingFortress.ogg", 0, MUSIC_LOOP_WFZ)
 			PlayMusic(0)
 			break
 
 		case 16
-			SetMusicTrack("Extra.ogg", 0, 59852)
+			SetMusicTrack("Extra.ogg", 0, MUSIC_LOOP_PPZ)
 			PlayMusic(0)
 			break
 
@@ -301,7 +326,7 @@ function MenuControl_SoundTestPlayer
 			break
 
 		case 18
-			SetMusicTrack("SpecialStage.ogg", 0, 496644)
+			SetMusicTrack("SpecialStage.ogg", 0, MUSIC_LOOP_SPECIAL)
 			PlayMusic(0)
 			break
 
@@ -326,7 +351,7 @@ function MenuControl_SoundTestPlayer
 			break
 
 		case 23
-			SetMusicTrack("Invincibility.ogg", 0, 38679)
+			SetMusicTrack("Invincibility.ogg", 0, MUSIC_LOOP_INV)
 			PlayMusic(0)
 			break
 
@@ -430,12 +455,12 @@ event ObjectMain
 				end if
 			end if
 
-			if object.currentSelection > 22
+			if object.currentSelection > MAX_SELECTION_COUNT
 				object.currentSelection = 0
 			end if
 
 			if object.currentSelection < 0
-				object.currentSelection = 22
+				object.currentSelection = MAX_SELECTION_COUNT
 			end if
 
 			temp0 = object.currentSelection

--- a/Sonic 2/Scripts/LevelSelect/MenuDPad.txt
+++ b/Sonic 2/Scripts/LevelSelect/MenuDPad.txt
@@ -8,10 +8,16 @@
 // ========================
 // Aliases
 // ========================
+// value0 is skipped over
 private alias object.value1 : object.pressedLR
 
 // Kept here for mod compatability reasons, please don't use this if possible
-private alias MenuControl_optionsMenuOpen : MenuControl_value2
+private alias MenuControl_value2 : MenuControl_optionsMenuOpen
+
+
+// ========================
+// Events
+// ========================
 
 event ObjectMain
 	if MenuControl_optionsMenuOpen == false

--- a/Sonic 2/Scripts/MCZ/MCZSetup.txt
+++ b/Sonic 2/Scripts/MCZ/MCZSetup.txt
@@ -26,7 +26,6 @@ private alias 10 : SLOT_ZONESETUP
 private alias 25 : SLOT_MUSICEVENT_CHANGE
 private alias 26 : SLOT_MUSICEVENT_BOSS
 
-
 // Music Events
 private alias  0 : MUSICEVENT_FADETOBOSS
 private alias  1 : MUSICEVENT_FADETOSTAGE
@@ -35,6 +34,17 @@ private alias  2 : MUSICEVENT_TRANSITION
 private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
+
+// Music Loops
+private alias 99356 : MUSIC_LOOP_MCZ_1P
+private alias 79574 : MUSIC_LOOP_MCZ_1P_F
+
+private alias 18672 : MUSIC_LOOP_MCZ_2P // This is 18671 in the Sound Test and HPZ's initial music setting...
+private alias 15272 : MUSIC_LOOP_MCZ_2P_F
+
+private alias 38679 : MUSIC_LOOP_INV
+private alias 30897 : MUSIC_LOOP_INV_F
+
 
 // ========================
 // Function Declarations
@@ -62,20 +72,20 @@ function MCZSetup_SpeedUpMusic1P
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("MysticCave_F.ogg", TRACK_STAGE, 79574, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("MysticCave_F.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_1P_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("MysticCave_F.ogg", TRACK_STAGE, 79574)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("MysticCave_F.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_1P_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("MysticCave_F.ogg", TRACK_STAGE, 79574)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("MysticCave_F.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_1P_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -94,20 +104,20 @@ function MCZSetup_SlowDownMusic1P
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("MysticCave.ogg", TRACK_STAGE, 99356, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("MysticCave.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_1P, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("MysticCave.ogg", TRACK_STAGE, 99356)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679, 12500)
+			SetMusicTrack("MysticCave.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_1P)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("MysticCave.ogg", TRACK_STAGE, 99356)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("MysticCave.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_1P)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -126,18 +136,18 @@ function MCZSetup_SpeedUpMusic2P
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("MysticCave2_F.ogg", TRACK_STAGE, 15272, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("MysticCave2_F.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("MysticCave2_F.ogg", TRACK_STAGE, 15272)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("MysticCave2_F.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
-			SetMusicTrack("MysticCave2_F.ogg", TRACK_STAGE, 15272)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("MysticCave2_F.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -156,18 +166,18 @@ function MCZSetup_SlowDownMusic2P
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("MysticCave2.ogg", TRACK_STAGE, 18672, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("MysticCave2.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("MysticCave2.ogg", TRACK_STAGE, 18672)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679, 12500)
+			SetMusicTrack("MysticCave2.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
-			SetMusicTrack("MysticCave2.ogg", TRACK_STAGE, 18672)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("MysticCave2.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -196,11 +206,11 @@ end event
 
 event ObjectStartup
 	if options.vsMode == false
-		SetMusicTrack("MysticCave.ogg", TRACK_STAGE, 99356)
+		SetMusicTrack("MysticCave.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_1P)
 		SpeedUpMusic = MCZSetup_SpeedUpMusic1P
 		SlowDownMusic = MCZSetup_SlowDownMusic1P
 	else
-		SetMusicTrack("MysticCave2.ogg", TRACK_STAGE, 18672)
+		SetMusicTrack("MysticCave2.ogg", TRACK_STAGE, MUSIC_LOOP_MCZ_2P)
 		SpeedUpMusic = MCZSetup_SpeedUpMusic2P
 		SlowDownMusic = MCZSetup_SlowDownMusic2P
 	end if

--- a/Sonic 2/Scripts/MPZ/MPZSetup.txt
+++ b/Sonic 2/Scripts/MPZ/MPZSetup.txt
@@ -57,6 +57,14 @@ private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
 
+// Music Loops
+private alias 309378 : MUSIC_LOOP_MPZ
+private alias 247394 : MUSIC_LOOP_MPZ_F
+
+private alias 38679  : MUSIC_LOOP_INV
+private alias 30897  : MUSIC_LOOP_INV_F
+
+
 // ========================
 // Function Declarations
 // ========================
@@ -106,20 +114,20 @@ function MPZSetup_SpeedUpMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("Metropolis_F.ogg", TRACK_STAGE, 247394, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("Metropolis_F.ogg", TRACK_STAGE, MUSIC_LOOP_MPZ_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("Metropolis_F.ogg", TRACK_STAGE, 247394)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("Metropolis_F.ogg", TRACK_STAGE, MUSIC_LOOP_MPZ_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_GAMEOVER
 		case TRACK_SUPER
-			SetMusicTrack("Metropolis_F.ogg", TRACK_STAGE, 247394)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("Metropolis_F.ogg", TRACK_STAGE, MUSIC_LOOP_MPZ_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -141,20 +149,20 @@ function MPZSetup_SlowDownMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("Metropolis.ogg", TRACK_STAGE, 309378, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("Metropolis.ogg", TRACK_STAGE, MUSIC_LOOP_MPZ, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("Metropolis.ogg", TRACK_STAGE, 309378)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679, 12500)
+			SetMusicTrack("Metropolis.ogg", TRACK_STAGE, MUSIC_LOOP_MPZ)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_GAMEOVER
 		case TRACK_SUPER
-			SetMusicTrack("Metropolis.ogg", TRACK_STAGE, 309378)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("Metropolis.ogg", TRACK_STAGE, MUSIC_LOOP_MPZ)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else

--- a/Sonic 2/Scripts/OOZ/OOZSetup.txt
+++ b/Sonic 2/Scripts/OOZ/OOZSetup.txt
@@ -57,7 +57,6 @@ private alias 10 : SLOT_ZONESETUP
 private alias 25 : SLOT_MUSICEVENT_CHANGE
 private alias 26 : SLOT_MUSICEVENT_BOSS
 
-
 // Music Events
 private alias  0 : MUSICEVENT_FADETOBOSS
 private alias  1 : MUSICEVENT_FADETOSTAGE
@@ -66,6 +65,14 @@ private alias  2 : MUSICEVENT_TRANSITION
 private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
+
+// Music Loops
+private alias 293572 : MUSIC_LOOP_OOZ
+private alias 235236 : MUSIC_LOOP_OOZ_F
+
+private alias 38679  : MUSIC_LOOP_INV
+private alias 30897  : MUSIC_LOOP_INV_F
+
 
 // ========================
 // Function Declarations
@@ -76,6 +83,7 @@ reserve function OOZSetup_HandleOilMovement
 reserve function OOZSetup_HandlePlayerOilSlide
 reserve function OOZSetup_SpeedUpMusic
 reserve function OOZSetup_SlowDownMusic
+
 
 // ========================
 // Tables
@@ -393,20 +401,20 @@ function OOZSetup_SpeedUpMusic
 	if temp0 == 0
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("OilOcean_F.ogg", TRACK_STAGE, 235236, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("OilOcean_F.ogg", TRACK_STAGE, MUSIC_LOOP_OOZ_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("OilOcean_F.ogg", TRACK_STAGE, 235236)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("OilOcean_F.ogg", TRACK_STAGE, MUSIC_LOOP_OOZ_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("OilOcean_F.ogg", TRACK_STAGE, 235236)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("OilOcean_F.ogg", TRACK_STAGE, MUSIC_LOOP_OOZ_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -425,20 +433,20 @@ function OOZSetup_SlowDownMusic
 	if temp0 == 0
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("OilOcean.ogg", TRACK_STAGE, 293572, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("OilOcean.ogg", TRACK_STAGE, MUSIC_LOOP_OOZ, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("OilOcean.ogg", TRACK_STAGE, 293572)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679, 12500)
+			SetMusicTrack("OilOcean.ogg", TRACK_STAGE, MUSIC_LOOP_OOZ)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("OilOcean.ogg", TRACK_STAGE, 293572)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("OilOcean.ogg", TRACK_STAGE, MUSIC_LOOP_OOZ)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -634,7 +642,7 @@ end event
 
 
 event ObjectStartup
-	SetMusicTrack("OilOcean.ogg", TRACK_STAGE, 293572)
+	SetMusicTrack("OilOcean.ogg", TRACK_STAGE, MUSIC_LOOP_OOZ)
 
 	SpeedUpMusic = OOZSetup_SpeedUpMusic
 	SlowDownMusic = OOZSetup_SlowDownMusic

--- a/Sonic 2/Scripts/Players/PlayerObject.txt
+++ b/Sonic 2/Scripts/Players/PlayerObject.txt
@@ -84,6 +84,8 @@ private alias object.collisionPlane	 :	player.collisionPlane
 private alias object.floorSensorC	 :	player.floorSensorC
 private alias object.floorSensorL	 :	player.floorSensorL
 private alias object.floorSensorR	 :	player.floorSensorR
+private alias object.floorSensorC	 :	player.floorSensorLC
+private alias object.floorSensorC	 :	player.floorSensorRC
 private alias object.tileCollisions	 :	player.tileCollisions
 private alias object.priority		 :	player.priority
 
@@ -168,6 +170,7 @@ private alias object.value0 : vsGame.timer
 
 // VSGame States
 private alias 2 : VSGAME_FADEOUT
+
 
 // ========================
 // Function Declarations
@@ -709,9 +712,9 @@ function PlayerObject_ProcessSuperState
 		end if
 
 		player.invincibleTimer = 0
-		currentPlayer = object.entityPos
-		if object.state != PlayerObject_Death
-			if object.state != PlayerObject_Drown
+		currentPlayer = player.entityPos
+		if player.state != PlayerObject_Death
+			if player.state != PlayerObject_Drown
 				arrayPos0 = currentPlayer
 				arrayPos0 += playerCount
 				CallFunction(PlayerObject_RestorePowerup)
@@ -1322,7 +1325,8 @@ function PlayerObject_ProcessPlayer
 
 		if player.scrollDelay == 0
 			if player.entityPos == screen.cameraTarget
-				screen.cameraStyle = 0 // Set the camera state to unlocked
+				// Restore the camera's state
+				screen.cameraStyle = CAMERASTYLE_FOLLOW
 			end if
 		end if
 	end if
@@ -1738,50 +1742,50 @@ end function
 function PlayerObject_HandleAirMovement
 	player.scrollTracking = true
 	player.yvel += player.gravityStrength
-	if object.yvel < player.jumpCap
-		if object.jumpHold == false
+	if player.yvel < player.jumpCap
+		if player.jumpHold == false
 			if player.timer > 0
-				object.yvel = player.jumpCap
-				temp0 = object.speed
+				player.yvel = player.jumpCap
+				temp0 = player.speed
 				temp0 >>= 5
-				object.speed -= temp0
+				player.speed -= temp0
 			end if
 		end if
 	end if
-	object.xvel = object.speed
+	player.xvel = player.speed
 
-	if object.rotation < 256
-		if object.rotation > 0
-			object.rotation -= 4
+	if player.rotation < 256
+		if player.rotation > 0
+			player.rotation -= 4
 		else
-			object.rotation = 0
+			player.rotation = 0
 		end if
 	else
-		if object.rotation < 512
-			object.rotation += 4
+		if player.rotation < 512
+			player.rotation += 4
 		else
-			object.rotation = 0
+			player.rotation = 0
 		end if
 	end if
 
-	object.collisionMode = CMODE_FLOOR
-	if object.animation == ANI_JUMPING
-		object.animationSpeed = player.customRollAnimSpeed
+	player.collisionMode = CMODE_FLOOR
+	if player.animation == ANI_JUMPING
+		player.animationSpeed = player.customRollAnimSpeed
 	end if
 end function
 
 
 function PlayerObject_ResetOnFloor
-	object.scrollTracking = 0
-	Cos256(temp0, object.angle)
-	temp0 *= object.speed
+	player.scrollTracking = 0
+	Cos256(temp0, player.angle)
+	temp0 *= player.speed
 	temp0 >>= 8
-	object.xvel = temp0
+	player.xvel = temp0
 
-	Sin256(temp0, object.angle)
-	temp0 *= object.speed
+	Sin256(temp0, player.angle)
+	temp0 *= player.speed
 	temp0 >>= 8
-	object.yvel = temp0
+	player.yvel = temp0
 end function
 
 
@@ -1789,55 +1793,55 @@ function PlayerObject_StartJump
 
 	// Let's mind our head!!!
 	temp1 = false
-	if object.collisionMode == CMODE_FLOOR
-		temp6 = object.xpos
-		temp7 = object.ypos
-		temp0 = object.collisionTop
+	if player.collisionMode == CMODE_FLOOR
+		temp6 = player.xpos
+		temp7 = player.ypos
+		temp0 = player.collisionTop
 		temp0 -= 2
-		ObjectTileCollision(CSIDE_ROOF, 0, temp0, object.collisionPlane)
+		ObjectTileCollision(CSIDE_ROOF, 0, temp0, player.collisionPlane)
 		
 		temp1 = checkResult
-		object.xpos = temp6
-		object.ypos = temp7
-		temp0 = object.collisionBottom
-		if object.animation != ANI_JUMPING
-			object.iypos -= player.jumpOffset
+		player.xpos = temp6
+		player.ypos = temp7
+		temp0 = player.collisionBottom
+		if player.animation != ANI_JUMPING
+			player.iypos -= player.jumpOffset
 			temp0 += player.jumpOffset
 		end if
-		ObjectTileCollision(CSIDE_FLOOR, 0, temp0, object.collisionPlane)
+		ObjectTileCollision(CSIDE_FLOOR, 0, temp0, player.collisionPlane)
 	end if
 
 	if temp1 == false
-		object.controlLock = 0
-		object.gravity = GRAVITY_AIR
+		player.controlLock = 0
+		player.gravity = GRAVITY_AIR
 		temp1 = player.jumpStrength
 		temp1 += player.gravityStrength
-		Sin256(object.xvel, object.angle)
-		object.xvel *= temp1
-		Cos256(temp0, object.angle)
-		temp0 *= object.speed
-		object.xvel += temp0
-		object.xvel >>= 8
+		Sin256(player.xvel, player.angle)
+		player.xvel *= temp1
+		Cos256(temp0, player.angle)
+		temp0 *= player.speed
+		player.xvel += temp0
+		player.xvel >>= 8
 
-		Sin256(object.yvel, object.angle)
-		object.yvel *= object.speed
-		Cos256(temp0, object.angle)
+		Sin256(player.yvel, player.angle)
+		player.yvel *= player.speed
+		Cos256(temp0, player.angle)
 		temp0 *= temp1
-		object.yvel -= temp0
-		object.yvel >>= 8
+		player.yvel -= temp0
+		player.yvel >>= 8
 
-		object.speed = object.xvel
-		object.scrollTracking = true
-		object.animation = ANI_JUMPING
-		object.angle = 0
-		object.collisionMode = CMODE_FLOOR
+		player.speed = player.xvel
+		player.scrollTracking = true
+		player.animation = ANI_JUMPING
+		player.angle = 0
+		player.collisionMode = CMODE_FLOOR
 		player.timer = 1
 		CallFunction(PlayerObject_RollAnimSpd)
 
-		if object.state == PlayerObject_HandleRolling
-			object.state = PlayerObject_RollingJump
+		if player.state == PlayerObject_HandleRolling
+			player.state = PlayerObject_RollingJump
 		else
-			object.state = PlayerObject_HandleAir
+			player.state = PlayerObject_HandleAir
 		end if
 
 		PlaySfx(SfxName[Jump], false)
@@ -1848,17 +1852,17 @@ end function
 
 
 function PlayerObject_StartSpindash
-	object.state = PlayerObject_HandleSpindash
-	object.animation = ANI_SPINDASH
+	player.state = PlayerObject_HandleSpindash
+	player.animation = ANI_SPINDASH
 	player.abilityTimer = 0
 	PlaySfx(SfxName[Charge], false)
 
-	CreateTempObject(TypeName[Dust Puff], object.entityPos, object.xpos, object.ypos)
-	object[tempObjectPos].iypos = object.collisionBottom
-	object[tempObjectPos].ypos += object.ypos
+	CreateTempObject(TypeName[Dust Puff], player.entityPos, player.xpos, player.ypos)
+	object[tempObjectPos].iypos = player.collisionBottom
+	object[tempObjectPos].ypos += player.ypos
 	object[tempObjectPos].frame = 4
 	object[tempObjectPos].drawOrder = 4
-	object[tempObjectPos].direction = object.direction
+	object[tempObjectPos].direction = player.direction
 end function
 
 
@@ -1867,8 +1871,8 @@ function PlayerObject_Transforming
 
 	player.timer--
 	if player.timer == 0
-		object.state = PlayerObject_HandleAir
-		object.animation = ANI_WALKING
+		player.state = PlayerObject_HandleAir
+		player.animation = ANI_WALKING
 	end if
 end function
 
@@ -1914,41 +1918,41 @@ function PlayerObject_BubbleBounce
 	temp0 |= checkResult
 
 	if temp0 == true
-		object.state = PlayerObject_HandleAir
+		player.state = PlayerObject_HandleAir
 	else
-		if object.gravity == GRAVITY_AIR
+		if player.gravity == GRAVITY_AIR
 			CallFunction(PlayerObject_HandleAirMovement)
 		else
 			player.jumpAbilityState = 1
-			object.gravity = GRAVITY_AIR
+			player.gravity = GRAVITY_AIR
 			if player.jumpStrength == 0x38000
 				temp1 = -0x40000
 			else
 				temp1 = -0x78000
 			end if
 			temp1 += player.gravityStrength
-			Sin256(object.xvel, object.angle)
-			object.xvel *= temp1
-			Cos256(temp0, object.angle)
-			temp0 *= object.speed
-			object.xvel += temp0
-			object.xvel >>= 8
+			Sin256(player.xvel, player.angle)
+			player.xvel *= temp1
+			Cos256(temp0, player.angle)
+			temp0 *= player.speed
+			player.xvel += temp0
+			player.xvel >>= 8
 
-			Sin256(object.yvel, object.angle)
-			object.yvel *= object.speed
-			Cos256(temp0, object.angle)
+			Sin256(player.yvel, player.angle)
+			player.yvel *= player.speed
+			Cos256(temp0, player.angle)
 			temp0 *= temp1
-			object.yvel = temp0
-			object.yvel >>= 8
+			player.yvel = temp0
+			player.yvel >>= 8
 
-			object.speed = object.xvel
-			object.scrollTracking = true
-			object.animation = ANI_JUMPING
-			object.angle = 0
-			object.collisionMode = CMODE_FLOOR
+			player.speed = player.xvel
+			player.scrollTracking = true
+			player.animation = ANI_JUMPING
+			player.angle = 0
+			player.collisionMode = CMODE_FLOOR
 			player.timer = 1
 			CallFunction(PlayerObject_RollAnimSpd)
-			object.state = PlayerObject_HandleAir
+			player.state = PlayerObject_HandleAir
 			PlaySfx(SfxName[Bubble Bounce], false)
 			object[+playerCount].state = 4
 		end if
@@ -1957,7 +1961,7 @@ end function
 
 
 function PlayerObject_JumpAbility_Sonic
-	if object.jumpPress == true
+	if player.jumpPress == true
 		CheckEqual(specialStage.emeralds, 0b01111111)
 		temp0 = checkResult
 		CheckGreater(player.rings, 49)
@@ -1968,7 +1972,7 @@ function PlayerObject_JumpAbility_Sonic
 		temp0 &= checkResult
 
 		if temp0 == true
-			currentPlayer = object.entityPos
+			currentPlayer = player.entityPos
 			CallFunction(PlayerObject_SuperTransform)
 		else
 			CheckEqual(player.invincibleTimer, 0)
@@ -1984,7 +1988,7 @@ function PlayerObject_JumpAbility_Sonic
 					if temp0 > 0
 						PlaySfx(SfxName[Insta Shield], false)
 						if object[+playerCount].type == TypeName[Blank Object]
-							currentPlayer = object.entityPos
+							currentPlayer = player.entityPos
 							arrayPos0 = currentPlayer
 							arrayPos0 += playerCount
 							ResetObjectEntity(arrayPos0, TypeName[Insta Shield], 0, 0, 0)
@@ -1993,8 +1997,8 @@ function PlayerObject_JumpAbility_Sonic
 
 						player.jumpAbilityState = 2
 						object[+playerCount].state = 1
-						if object.state == PlayerObject_RollingJump
-							object.state = PlayerObject_HandleAir
+						if player.state == PlayerObject_RollingJump
+							player.state = PlayerObject_HandleAir
 						end if
 					end if
 					break
@@ -2004,62 +2008,62 @@ function PlayerObject_JumpAbility_Sonic
 
 				case SHIELD_BUBBLE
 					PlaySfx(SfxName[Bubble Bounce], false)
-					object.yvel = 0x80000
-					object.xvel = 0
-					object.speed = object.xvel
+					player.yvel = 0x80000
+					player.xvel = 0
+					player.speed = player.xvel
 					player.jumpAbilityState = 2
-					object.state = PlayerObject_BubbleBounce
+					player.state = PlayerObject_BubbleBounce
 					object[+playerCount].state = 2
 					break
 
 				case SHIELD_FIRE
 					PlaySfx(SfxName[Fire Dash], false)
-					GetBit(temp0, object.direction, 0)
+					GetBit(temp0, player.direction, 0)
 					if temp0 == false
-						object.xvel = 0x80000
+						player.xvel = 0x80000
 					else
-						object.xvel = -0x80000
+						player.xvel = -0x80000
 					end if
 
-					object.speed = object.xvel
-					object.yvel = 0
+					player.speed = player.xvel
+					player.yvel = 0
 					player.jumpAbilityState = 2
-					if object.entityPos == screen.cameraTarget
+					if player.entityPos == screen.cameraTarget
 						player.scrollDelay = 15
-						screen.cameraStyle = 4
+						screen.cameraStyle = CAMERASTYLE_HLOCKED
 					end if
 
-					if object.state == PlayerObject_RollingJump
-						object.state = PlayerObject_HandleAir
+					if player.state == PlayerObject_RollingJump
+						player.state = PlayerObject_HandleAir
 					end if
 
 					object[+playerCount].state = 2
-					object[+playerCount].direction = object.direction
+					object[+playerCount].direction = player.direction
 					break
 
 				case SHIELD_LIGHTNING
 					PlaySfx(SfxName[Lightning Jump], false)
-					object.yvel = -0x58000
+					player.yvel = -0x58000
 					player.jumpAbilityState = 2
 
-					CreateTempObject(TypeName[Lightning Spark], 0, object.xpos, object.ypos)
+					CreateTempObject(TypeName[Lightning Spark], 0, player.xpos, player.ypos)
 					object[tempObjectPos].xvel = -0x20000
 					object[tempObjectPos].yvel = -0x20000
 
-					CreateTempObject(TypeName[Lightning Spark], 0, object.xpos, object.ypos)
+					CreateTempObject(TypeName[Lightning Spark], 0, player.xpos, player.ypos)
 					object[tempObjectPos].xvel = 0x20000
 					object[tempObjectPos].yvel = -0x20000
 
-					CreateTempObject(TypeName[Lightning Spark], 0, object.xpos, object.ypos)
+					CreateTempObject(TypeName[Lightning Spark], 0, player.xpos, player.ypos)
 					object[tempObjectPos].xvel = -0x20000
 					object[tempObjectPos].yvel = 0x20000
 
-					CreateTempObject(TypeName[Lightning Spark], 0, object.xpos, object.ypos)
+					CreateTempObject(TypeName[Lightning Spark], 0, player.xpos, player.ypos)
 					object[tempObjectPos].xvel = 0x20000
 					object[tempObjectPos].yvel = 0x20000
 
-					if object.state == PlayerObject_RollingJump
-						object.state = PlayerObject_HandleAir
+					if player.state == PlayerObject_RollingJump
+						player.state = PlayerObject_HandleAir
 					end if
 					break
 				end switch
@@ -2070,7 +2074,7 @@ end function
 
 
 function PlayerObject_JumpAbility_Tails
-	if object.jumpPress == true
+	if player.jumpPress == true
 		CheckEqual(specialStage.emeralds, 0b01111111)
 		temp0 = checkResult
 		CheckGreater(player.rings, 49)
@@ -2083,18 +2087,18 @@ function PlayerObject_JumpAbility_Tails
 		temp0 &= checkResult
 
 		if temp0 == true
-			currentPlayer = object.entityPos
+			currentPlayer = player.entityPos
 			CallFunction(PlayerObject_SuperTransform)
 		else
 			player.timer = 0
-			object.state = PlayerObject_HandleTailsFlight
+			player.state = PlayerObject_HandleTailsFlight
 			player.flightVelocity = 0x800
 
 			if player.gravityStrength == 0x3800
 				PlaySfx(SfxName[Flying], true)
-				object.animation = ANI_FLYING
+				player.animation = ANI_FLYING
 			else
-				object.animation = ANI_SWIMMING
+				player.animation = ANI_SWIMMING
 			end if
 		end if
 	end if
@@ -2102,7 +2106,7 @@ end function
 
 
 function PlayerObject_JumpAbility_Knux
-	if object.jumpPress == true
+	if player.jumpPress == true
 		CheckEqual(specialStage.emeralds, 0b01111111)
 		temp0 = checkResult
 		CheckGreater(player.rings, 49)
@@ -2111,108 +2115,108 @@ function PlayerObject_JumpAbility_Knux
 		temp0 &= checkResult
 
 		if temp0 == true
-			currentPlayer = object.entityPos
+			currentPlayer = player.entityPos
 			CallFunction(PlayerObject_SuperTransform)
 		else
-			object.speed = 0x40000
-			if object.yvel < 0
-				object.yvel = 0
+			player.speed = 0x40000
+			if player.yvel < 0
+				player.yvel = 0
 			end if
 
-			if object.direction == FLIP_NONE
-				object.state = PlayerObject_KnuxGlideRight
-				object.xvel = 0x40000
+			if player.direction == FLIP_NONE
+				player.state = PlayerObject_KnuxGlideRight
+				player.xvel = 0x40000
 				player.timer = 0
 			else
-				object.state = PlayerObject_KnuxGlideLeft
-				object.xvel = -0x40000
+				player.state = PlayerObject_KnuxGlideLeft
+				player.xvel = -0x40000
 				player.timer = 256
 			end if
 
-			object.animation = ANI_GLIDING
-			object.frame = 2
+			player.animation = ANI_GLIDING
+			player.frame = 2
 		end if
 	end if
 end function
 
 
 function PlayerObject_HandleGround
-	if object.animation != ANI_SKIDDING
+	if player.animation != ANI_SKIDDING
 		temp7 = true
 	else
 		temp7 = false
 	end if
 
 	CallFunction(PlayerObject_HandleMovement)
-	if object.gravity == GRAVITY_AIR
-		object.state = PlayerObject_HandleAir
+	if player.gravity == GRAVITY_AIR
+		player.state = PlayerObject_HandleAir
 		CallFunction(PlayerObject_HandleAirMovement)
 	else
 		CallFunction(PlayerObject_ResetOnFloor)
-		if object.speed == 0
-			if object.collisionMode == CMODE_FLOOR
+		if player.speed == 0
+			if player.collisionMode == CMODE_FLOOR
 				switch player.character
 				case PlayerName[SONIC]
 					if PlayerObject_SuperState == SUPERSTATE_SUPER
-						object.animation = ANI_STOPPED
+						player.animation = ANI_STOPPED
 						player.timer = 0
-						if object.floorSensorC == false
-							if object.floorSensorR == false
-								object.animation = ANI_FLAILING1
-								object.direction = FLIP_NONE
+						if player.floorSensorC == false
+							if player.floorSensorR == false
+								player.animation = ANI_FLAILING1
+								player.direction = FLIP_NONE
 							end if
 
-							if object.floorSensorL == false
-								object.animation = ANI_FLAILING1
-								object.direction = FLIP_X
+							if player.floorSensorL == false
+								player.animation = ANI_FLAILING1
+								player.direction = FLIP_X
 							end if
 						end if
 					else
 						if player.timer < 240
-							object.animation = ANI_STOPPED
+							player.animation = ANI_STOPPED
 							player.timer++
 						else
-							object.animation = ANI_WAITING
+							player.animation = ANI_WAITING
 							player.timer++
 							if player.timer == 0x4B0
 								player.timer = 0
-								object.state = PlayerObject_HandleBored2
+								player.state = PlayerObject_HandleBored2
 							end if
 						end if
 
-						if object.direction == FLIP_NONE
-							if object.floorSensorR == false
-								if object.floorSensorC == false
+						if player.direction == FLIP_NONE
+							if player.floorSensorR == false
+								if player.floorSensorC == false
 									player.timer = 0
-									if object.floorSensorLC == false
-										object.animation = ANI_FLAILING3
+									if player.floorSensorLC == false
+										player.animation = ANI_FLAILING3
 									else
-										object.animation = ANI_FLAILING1
+										player.animation = ANI_FLAILING1
 									end if
 								end if
 							else
-								if object.floorSensorL == false
-									if object.floorSensorC == false
+								if player.floorSensorL == false
+									if player.floorSensorC == false
 										player.timer = 0
-										object.animation = ANI_FLAILING2
+										player.animation = ANI_FLAILING2
 									end if
 								end if
 							end if
 						else
-							if object.floorSensorL == false
-								if object.floorSensorC == false
+							if player.floorSensorL == false
+								if player.floorSensorC == false
 									player.timer = 0
-									if object.floorSensorRC == false
-										object.animation = ANI_FLAILING3
+									if player.floorSensorRC == false
+										player.animation = ANI_FLAILING3
 									else
-										object.animation = ANI_FLAILING1
+										player.animation = ANI_FLAILING1
 									end if
 								end if
 							else
-								if object.floorSensorR == false
-									if object.floorSensorC == false
+								if player.floorSensorR == false
+									if player.floorSensorC == false
 										player.timer = 0
-										object.animation = ANI_FLAILING2
+										player.animation = ANI_FLAILING2
 									end if
 								end if
 							end if
@@ -2222,62 +2226,62 @@ function PlayerObject_HandleGround
 
 				case PlayerName[TAILS]
 					if player.timer < 240
-						object.animation = ANI_STOPPED
+						player.animation = ANI_STOPPED
 						player.timer++
 					else
-						object.animation = ANI_WAITING
+						player.animation = ANI_WAITING
 					end if
 
-					if object.floorSensorC == false
-						if object.floorSensorR == false
+					if player.floorSensorC == false
+						if player.floorSensorR == false
 							player.timer = 0
-							object.animation = ANI_FLAILING1
-							object.direction = FLIP_NONE
+							player.animation = ANI_FLAILING1
+							player.direction = FLIP_NONE
 						end if
-						if object.floorSensorL == false
+						if player.floorSensorL == false
 							player.timer = 0
-							object.animation = ANI_FLAILING1
-							object.direction = FLIP_X
+							player.animation = ANI_FLAILING1
+							player.direction = FLIP_X
 						end if
 					end if
 					break
 
 				case PlayerName[KNUCKLES]
 					if player.timer < 240
-						object.animation = ANI_STOPPED
+						player.animation = ANI_STOPPED
 						player.timer++
 					else
-						object.animation = ANI_WAITING
+						player.animation = ANI_WAITING
 						player.timer++
 						if player.timer == 834
 							player.timer = 0
-							object.animation = ANI_STOPPED
+							player.animation = ANI_STOPPED
 						end if
 					end if
 
-					if object.floorSensorC == false
-						if object.floorSensorR == false
+					if player.floorSensorC == false
+						if player.floorSensorR == false
 							player.timer = 0
-							object.animation = ANI_FLAILING1
-							if object.direction == FLIP_X
-								object.prevAnimation = ANI_FLAILING1
-								object.frame = 4
-								object.animationTimer = 0
-								object.animationSpeed = 0
+							player.animation = ANI_FLAILING1
+							if player.direction == FLIP_X
+								player.prevAnimation = ANI_FLAILING1
+								player.frame = 4
+								player.animationTimer = 0
+								player.animationSpeed = 0
 							end if
-							object.direction = FLIP_NONE
+							player.direction = FLIP_NONE
 						end if
 
-						if object.floorSensorL == false
+						if player.floorSensorL == false
 							player.timer = 0
-							object.animation = ANI_FLAILING1
-							if object.direction == FLIP_NONE
-								object.prevAnimation = ANI_FLAILING1
-								object.frame = 4
-								object.animationTimer = 0
-								object.animationSpeed = 0
+							player.animation = ANI_FLAILING1
+							if player.direction == FLIP_NONE
+								player.prevAnimation = ANI_FLAILING1
+								player.frame = 4
+								player.animationTimer = 0
+								player.animationSpeed = 0
 							end if
-							object.direction = FLIP_X
+							player.direction = FLIP_X
 						end if
 					end if
 					break
@@ -2285,27 +2289,27 @@ function PlayerObject_HandleGround
 			end if
 		else
 			player.timer = 0
-			if object.speed > 0
-				if object.speed < 0x5F5C2
-					object.animation = ANI_WALKING
+			if player.speed > 0
+				if player.speed < 0x5F5C2
+					player.animation = ANI_WALKING
 					CallFunction(PlayerObject_WalkAnimSpd)
 				else
-					if object.speed > 0x9FFFF
-						object.animation = ANI_PEELOUT
+					if player.speed > 0x9FFFF
+						player.animation = ANI_PEELOUT
 					else
-						object.animation = ANI_RUNNING
+						player.animation = ANI_RUNNING
 					end if
 					CallFunction(PlayerObject_RunAnimSpd)
 				end if
 			else
-				if object.speed > -0x5F5C2
-					object.animation = ANI_WALKING
+				if player.speed > -0x5F5C2
+					player.animation = ANI_WALKING
 					CallFunction(PlayerObject_WalkAnimSpd)
 				else
-					if object.speed < -0x9FFFF
-						object.animation = ANI_PEELOUT
+					if player.speed < -0x9FFFF
+						player.animation = ANI_PEELOUT
 					else
-						object.animation = ANI_RUNNING
+						player.animation = ANI_RUNNING
 					end if
 					CallFunction(PlayerObject_RunAnimSpd)
 				end if
@@ -2316,83 +2320,83 @@ function PlayerObject_HandleGround
 			if temp7 == true
 				PlaySfx(SfxName[Skidding], false)
 			end if
-			object.animation = ANI_SKIDDING
-			object.animationSpeed = 0
+			player.animation = ANI_SKIDDING
+			player.animationSpeed = 0
 			player.skidding--
 			if ringTimer == 0
-				CreateTempObject(TypeName[Dust Puff], 0, object.xpos, object.ypos)
-				object[tempObjectPos].iypos += object.collisionBottom
+				CreateTempObject(TypeName[Dust Puff], 0, player.xpos, player.ypos)
+				object[tempObjectPos].iypos += player.collisionBottom
 				object[tempObjectPos].drawOrder = player.sortedDrawOrder
 			end if
 
-			if object.speed > 0
-				object.direction = FLIP_NONE
+			if player.speed > 0
+				player.direction = FLIP_NONE
 			else
-				object.direction = FLIP_X
+				player.direction = FLIP_X
 			end if
 		end if
 
-		if object.collisionMode == CMODE_FLOOR
-			if object.pushing == 2
-				object.animation = ANI_PUSHING
-				object.animationSpeed = 0
+		if player.collisionMode == CMODE_FLOOR
+			if player.pushing == 2
+				player.animation = ANI_PUSHING
+				player.animationSpeed = 0
 			end if
 		end if
 
-		if object.jumpPress == true
+		if player.jumpPress == true
 			CallFunction(PlayerObject_StartJump)
 		else
-			if object.up == true
-				if object.speed == 0
-					if object.animation != ANI_FLAILING1
-						if object.animation != ANI_FLAILING2
-							object.state = PlayerObject_LookingUp
+			if player.up == true
+				if player.speed == 0
+					if player.animation != ANI_FLAILING1
+						if player.animation != ANI_FLAILING2
+							player.state = PlayerObject_LookingUp
 							player.timer = 0
 						else
-							object.up = false
-							object.down = false
+							player.up = false
+							player.down = false
 						end if
 					else
-						object.up = false
-						object.down = false
+						player.up = false
+						player.down = false
 					end if
 				end if
 			end if
 
-			if object.down == true
-				if object.speed == 0
-					if object.animation != ANI_FLAILING1
-						if object.animation != ANI_FLAILING2
-							object.state = PlayerObject_Crouching
+			if player.down == true
+				if player.speed == 0
+					if player.animation != ANI_FLAILING1
+						if player.animation != ANI_FLAILING2
+							player.state = PlayerObject_Crouching
 							player.timer = 0
 						else
-							object.up = false
-							object.down = false
+							player.up = false
+							player.down = false
 						end if
 					else
-						object.up = false
-						object.down = false
+						player.up = false
+						player.down = false
 					end if
 				else
-					if object.left == false
-						if object.right == false
-							if object.speed > 0
-								if object.speed > 0x8800
-									object.state = PlayerObject_HandleRolling
-									object.animation = ANI_JUMPING
-									if object.prevAnimation != ANI_JUMPING
-										object.iypos -= player.jumpOffset
+					if player.left == false
+						if player.right == false
+							if player.speed > 0
+								if player.speed > 0x8800
+									player.state = PlayerObject_HandleRolling
+									player.animation = ANI_JUMPING
+									if player.prevAnimation != ANI_JUMPING
+										player.iypos -= player.jumpOffset
 									end if
 
 									player.abilityTimer = 0x400
 									PlaySfx(SfxName[Rolling], false)
 								end if
 							else
-								if object.speed < -0x8800
-									object.state = PlayerObject_HandleRolling
-									object.animation = ANI_JUMPING
-									if object.prevAnimation != ANI_JUMPING
-										object.iypos -= player.jumpOffset
+								if player.speed < -0x8800
+									player.state = PlayerObject_HandleRolling
+									player.animation = ANI_JUMPING
+									if player.prevAnimation != ANI_JUMPING
+										player.iypos -= player.jumpOffset
 									end if
 
 									player.abilityTimer = 0x400
@@ -2409,36 +2413,36 @@ end function
 
 
 function PlayerObject_HandleBored2
-	if object.gravity == GRAVITY_AIR
-		object.state = PlayerObject_HandleAir
+	if player.gravity == GRAVITY_AIR
+		player.state = PlayerObject_HandleAir
 		CallFunction(PlayerObject_HandleAirMovement)
 	else
 		CallFunction(PlayerObject_ResetOnFloor)
-		if object.animation == ANI_CONTINUE_UP
-			if object.frame == 1
-				object.state = PlayerObject_HandleGround
+		if player.animation == ANI_CONTINUE_UP
+			if player.frame == 1
+				player.state = PlayerObject_HandleGround
 			end if
 		else
-			object.animation = ANI_BORED
+			player.animation = ANI_BORED
 		end if
 
-		if object.jumpPress == true
+		if player.jumpPress == true
 			CallFunction(PlayerObject_StartJump)
 		else
-			if object.up == true
-				object.animation = ANI_CONTINUE_UP
+			if player.up == true
+				player.animation = ANI_CONTINUE_UP
 			end if
 
-			if object.down == true
-				object.animation = ANI_CONTINUE_UP
+			if player.down == true
+				player.animation = ANI_CONTINUE_UP
 			end if
 
-			if object.left == true
-				object.animation = ANI_CONTINUE_UP
+			if player.left == true
+				player.animation = ANI_CONTINUE_UP
 			end if
 
-			if object.right == true
-				object.animation = ANI_CONTINUE_UP
+			if player.right == true
+				player.animation = ANI_CONTINUE_UP
 			end if
 		end if
 	end if
@@ -2447,74 +2451,74 @@ end function
 
 function PlayerObject_HandleAir
 	CallFunction(PlayerObject_AirAcceleration)
-	if object.gravity == GRAVITY_AIR
+	if player.gravity == GRAVITY_AIR
 		CallFunction(PlayerObject_HandleAirMovement)
 
-		if object.yvel > 0x20000
-			if object.animation == ANI_FLAILING1
-				object.animation = ANI_WALKING
+		if player.yvel > 0x20000
+			if player.animation == ANI_FLAILING1
+				player.animation = ANI_WALKING
 			end if
 
-			if object.animation == ANI_FLAILING2
-				object.animation = ANI_WALKING
+			if player.animation == ANI_FLAILING2
+				player.animation = ANI_WALKING
 			end if
 		end if
 
-		if object.animation == ANI_BOUNCING
-			if object.yvel >= 0
+		if player.animation == ANI_BOUNCING
+			if player.yvel >= 0
 				if player.animationReserve == ANI_STOPPED
 					player.animationReserve = ANI_WALKING
 				end if
-				object.animation = player.animationReserve
+				player.animation = player.animationReserve
 			end if
 		end if
 
-		if object.animation == ANI_SKIDDING
+		if player.animation == ANI_SKIDDING
 			if player.skidding > 0
 				player.skidding--
 			else
-				object.animation = ANI_WALKING
-				object.prevAnimation = ANI_WALKING
-				object.frame = 0
-				object.animationSpeed = 40
+				player.animation = ANI_WALKING
+				player.prevAnimation = ANI_WALKING
+				player.frame = 0
+				player.animationSpeed = 40
 			end if
 		end if
 
-		if object.animation == ANI_TWIRL
-			if object.animationSpeed == 40
-				if object.frame >= 12
-					object.animation = ANI_WALKING
-					object.prevAnimation = ANI_WALKING
-					object.frame = 0
+		if player.animation == ANI_TWIRL
+			if player.animationSpeed == 40
+				if player.frame >= 12
+					player.animation = ANI_WALKING
+					player.prevAnimation = ANI_WALKING
+					player.frame = 0
 				end if
 			else
-				if object.frame >= 24
-					object.animation = ANI_WALKING
-					object.prevAnimation = ANI_WALKING
-					object.frame = 0
-					object.animationSpeed = 40
+				if player.frame >= 24
+					player.animation = ANI_WALKING
+					player.prevAnimation = ANI_WALKING
+					player.frame = 0
+					player.animationSpeed = 40
 				end if
 			end if
 		end if
 
-		if object.animation == ANI_HURT
-			if object.yvel >= 0
+		if player.animation == ANI_HURT
+			if player.yvel >= 0
 				if player.animationReserve == ANI_STOPPED
 					player.animationReserve = ANI_WALKING
 				end if
-				object.animation = player.animationReserve
+				player.animation = player.animationReserve
 			end if
 		end if
 
-		if object.animation == ANI_JUMPING
+		if player.animation == ANI_JUMPING
 			if player.jumpAbilityState == 1
-				if object.yvel >= player.jumpCap
+				if player.yvel >= player.jumpCap
 					CallFunction(player.jumpAbility)
 				end if
 			end if
 		end if
 	else
-		object.state = PlayerObject_HandleGround
+		player.state = PlayerObject_HandleGround
 		CallFunction(PlayerObject_ResetOnFloor)
 		player.skidding = 0
 	end if
@@ -2525,30 +2529,30 @@ end function
 function PlayerObject_AirCtrlLock
 	CallFunction(PlayerObject_AirAcceleration)
 
-	if object.gravity == GRAVITY_AIR
+	if player.gravity == GRAVITY_AIR
 		CallFunction(PlayerObject_HandleAirMovement)
 	else
-		object.state = PlayerObject_TubeSwitch
+		player.state = PlayerObject_TubeSwitch
 		CallFunction(PlayerObject_ResetOnFloor)
 		player.skidding = 0
 	end if
 
-	object.animation = ANI_JUMPING
+	player.animation = ANI_JUMPING
 end function
 
 
 function PlayerObject_HandleRolling
 	CallFunction(PlayerObject_HandleRollingDecel)
 
-	if object.gravity == GRAVITY_AIR
-		object.state = PlayerObject_HandleAir
+	if player.gravity == GRAVITY_AIR
+		player.state = PlayerObject_HandleAir
 		player.timer = 0
 		CallFunction(PlayerObject_HandleAirMovement)
 	else
 		CallFunction(PlayerObject_RollAnimSpd)
-		object.animationSpeed = player.customRollAnimSpeed
+		player.animationSpeed = player.customRollAnimSpeed
 		CallFunction(PlayerObject_ResetOnFloor)
-		if object.jumpPress == true
+		if player.jumpPress == true
 			CallFunction(PlayerObject_StartJump)
 		end if
 	end if
@@ -2556,14 +2560,14 @@ end function
 
 
 function PlayerObject_RollingJump
-	object.left = false
-	object.right = false
+	player.left = false
+	player.right = false
 	CallFunction(PlayerObject_AirAcceleration)
 	
-	if object.gravity == GRAVITY_AIR
-		if object.animation == ANI_JUMPING
+	if player.gravity == GRAVITY_AIR
+		if player.animation == ANI_JUMPING
 			if player.jumpAbilityState == 1
-				if object.yvel >= player.jumpCap
+				if player.yvel >= player.jumpCap
 					CallFunction(player.jumpAbility)
 				end if
 			end if
@@ -2571,7 +2575,7 @@ function PlayerObject_RollingJump
 
 		CallFunction(PlayerObject_HandleAirMovement)
 	else
-		object.state = PlayerObject_HandleGround
+		player.state = PlayerObject_HandleGround
 		CallFunction(PlayerObject_ResetOnFloor)
 		player.skidding = 0
 	end if
@@ -2579,28 +2583,28 @@ end function
 
 
 function PlayerObject_LookingUp
-	if object.up == false
-		object.state = PlayerObject_HandleGround
+	if player.up == false
+		player.state = PlayerObject_HandleGround
 		player.timer = 0
 	else
 		if player.timer < 60
 			player.timer++
 		else
-			temp0 = object.ypos
+			temp0 = player.ypos
 			temp0 >>= 16
 			temp0 -= screen.cameraY
 			temp0 -= 112
-			if object.lookPosY > temp0
-				object.lookPosY -= 2
+			if player.lookPosY > temp0
+				player.lookPosY -= 2
 			end if
 		end if
 
-		object.animation = ANI_LOOKINGUP
-		if object.gravity == GRAVITY_AIR
-			object.state = PlayerObject_HandleAir
+		player.animation = ANI_LOOKINGUP
+		if player.gravity == GRAVITY_AIR
+			player.state = PlayerObject_HandleAir
 			player.timer = 0
 		else
-			if object.jumpPress == true
+			if player.jumpPress == true
 				CallFunction(PlayerObject_StartJump)
 			end if
 		end if
@@ -2609,28 +2613,28 @@ end function
 
 
 function PlayerObject_Crouching
-	if object.down == false
-		object.state = PlayerObject_HandleGround
+	if player.down == false
+		player.state = PlayerObject_HandleGround
 		player.timer = 0
 	else
 		if player.timer < 60
 			player.timer++
 		else
-			temp0 = object.ypos
+			temp0 = player.ypos
 			temp0 >>= 16
 			temp0 -= screen.cameraY
 			temp0 += 96
-			if object.lookPosY < temp0
-				object.lookPosY += 2
+			if player.lookPosY < temp0
+				player.lookPosY += 2
 			end if
 		end if
 
-		object.animation = ANI_LOOKINGDOWN
-		if object.gravity == GRAVITY_AIR
-			object.state = PlayerObject_HandleAir
+		player.animation = ANI_LOOKINGDOWN
+		if player.gravity == GRAVITY_AIR
+			player.state = PlayerObject_HandleAir
 			player.timer = 0
 		else
-			if object.jumpPress == true
+			if player.jumpPress == true
 				CallFunction(player.spindashFunction)
 			end if
 		end if
@@ -2639,19 +2643,19 @@ end function
 
 
 function PlayerObject_HandleSpindash
-	if object.gravity == GRAVITY_AIR
-		object.state = PlayerObject_HandleAir
-		object.speed = 0
+	if player.gravity == GRAVITY_AIR
+		player.state = PlayerObject_HandleAir
+		player.speed = 0
 	end if
 
-	if object.jumpPress == true
+	if player.jumpPress == true
 		if player.abilityTimer < 0x90000
 			player.abilityTimer += 0x20000
 		else
 			player.abilityTimer = 0x80000
 		end if
 
-		object.frame = 0
+		player.frame = 0
 		PlaySfx(SfxName[Charge], false)
 	else
 		temp0 = player.abilityTimer
@@ -2659,14 +2663,14 @@ function PlayerObject_HandleSpindash
 		player.abilityTimer -= temp0
 	end if
 
-	if object.down == false
+	if player.down == false
 		player.timer = 0
-		object.state = PlayerObject_HandleRolling
-		object.animation = ANI_JUMPING
-		object.iypos -= player.jumpOffset
-		if object.entityPos == screen.cameraTarget
+		player.state = PlayerObject_HandleRolling
+		player.animation = ANI_JUMPING
+		player.iypos -= player.jumpOffset
+		if player.entityPos == screen.cameraTarget
 			player.scrollDelay = 15
-			screen.cameraStyle = 4
+			screen.cameraStyle = CAMERASTYLE_HLOCKED
 		end if
 
 		temp0 = player.abilityTimer
@@ -2678,11 +2682,11 @@ function PlayerObject_HandleSpindash
 			temp0 += 0x80000
 		end if
 
-		if object.direction == FLIP_NONE
-			object.speed = temp0
+		if player.direction == FLIP_NONE
+			player.speed = temp0
 		else
-			object.speed = temp0
-			FlipSign(object.speed)
+			player.speed = temp0
+			FlipSign(player.speed)
 		end if
 
 		StopSfx(SfxName[Charge])
@@ -2697,8 +2701,8 @@ function PlayerObject_StartFlyCarry
 		player.flyCarryTimer--
 	end if
 
-	temp0 = object.xpos
-	temp1 = object.ypos
+	temp0 = player.xpos
+	temp1 = player.ypos
 	temp1 += 0x1F0000
 	if player[0].animation == ANI_JUMPING
 		temp1 += 0x50000
@@ -2709,7 +2713,7 @@ function PlayerObject_StartFlyCarry
 	if player[0].state != PlayerObject_HandleFlyCarry
 		CheckEqual(player[0].gravity, GRAVITY_GROUND)
 		temp2 = checkResult
-		CheckGreater(object.yvel, 0)
+		CheckGreater(player.yvel, 0)
 		temp2 &= checkResult
 
 		if temp2 == false
@@ -2749,38 +2753,38 @@ function PlayerObject_StartFlyCarry
 	end if
 
 	if player[0].state == PlayerObject_HandleFlyCarry
-		temp2 = object.xpos
-		temp3 = object.ypos
-		temp6 = object.xvel
-		temp7 = object.yvel
+		temp2 = player.xpos
+		temp3 = player.ypos
+		temp6 = player.xvel
+		temp7 = player.yvel
 		ProcessObjectMovement()
 
-		PlayerObject_flyCarryBuddyXPos = object.xpos
-		PlayerObject_flyCarryBuddyYPos = object.ypos
-		temp4 = object.xpos
+		PlayerObject_flyCarryBuddyXPos = player.xpos
+		PlayerObject_flyCarryBuddyYPos = player.ypos
+		temp4 = player.xpos
 		temp4 &= 0xFFFF0000
-		temp5 = object.ypos
+		temp5 = player.ypos
 		temp5 &= 0xFFFF0000
 		temp5 += 0x1F0000
-		object.xpos = temp2
-		object.ypos = temp3
-		object.xvel = temp6
-		object.yvel = temp7
+		player.xpos = temp2
+		player.ypos = temp3
+		player.xvel = temp6
+		player.yvel = temp7
 		stage.entityPos = 0
-		temp0 = object.xpos
+		temp0 = player.xpos
 		temp0 &= 0xFFFF0000
-		temp1 = object.ypos
+		temp1 = player.ypos
 		temp1 &= 0xFFFF0000
-		object.xvel = temp4
-		object.yvel = temp5
-		object.xvel -= temp0
-		object.yvel -= temp1
+		player.xvel = temp4
+		player.yvel = temp5
+		player.xvel -= temp0
+		player.yvel -= temp1
 		ProcessObjectMovement()
 
 		stage.entityPos = 1
-		player[0].collisionPlane = object.collisionPlane
-		player[0].speed = object.speed
-		player[0].direction = object.direction
+		player[0].collisionPlane = player.collisionPlane
+		player[0].speed = player.speed
+		player[0].direction = player.direction
 		PlayerObject_flyCarryLeaderXPos = player[0].xpos
 		PlayerObject_flyCarryLeaderYPos = player[0].ypos
 		temp2 = player[0].xpos
@@ -2806,14 +2810,14 @@ end function
 
 function PlayerObject_HandleFlyCarry
 	if player[1].state != PlayerObject_HandleTailsFlight
-		object.state = PlayerObject_HandleAir
+		player.state = PlayerObject_HandleAir
 	end if
 
 	temp0 = player[1].xpos
 	temp0 &= 0xFFFF0000
-	temp2 = object.xpos
+	temp2 = player.xpos
 	temp2 &= 0xFFFF0000
-	if object.xpos == PlayerObject_flyCarryLeaderXPos
+	if player.xpos == PlayerObject_flyCarryLeaderXPos
 		PlayerObject_flyCarryBuddyXPos &= 0xFFFF0000
 		temp1 = temp0
 		temp1 -= PlayerObject_flyCarryBuddyXPos
@@ -2821,35 +2825,35 @@ function PlayerObject_HandleFlyCarry
 	end if
 
 	if temp0 != temp2
-		if object.gravity == GRAVITY_GROUND
-			object.state = PlayerObject_HandleGround
+		if player.gravity == GRAVITY_GROUND
+			player.state = PlayerObject_HandleGround
 		else
-			object.state = PlayerObject_HandleAir
+			player.state = PlayerObject_HandleAir
 		end if
 	end if
 
-	if object.gravity == GRAVITY_GROUND
-		if object.yvel >= 0
-			object.state = PlayerObject_HandleGround
+	if player.gravity == GRAVITY_GROUND
+		if player.yvel >= 0
+			player.state = PlayerObject_HandleGround
 		end if
 	end if
 
-	if object.jumpPress != false
-		if object.down != false
+	if player.jumpPress != false
+		if player.down != false
 			if player.gravityStrength == 0x3800
-				object.yvel = -0x40000
+				player.yvel = -0x40000
 			else
-				object.yvel = -0x20000
+				player.yvel = -0x20000
 			end if
-			object.state = PlayerObject_HandleAir
-			object.animation = ANI_JUMPING
+			player.state = PlayerObject_HandleAir
+			player.animation = ANI_JUMPING
 		end if
 	end if
 
-	if object.state == PlayerObject_HandleFlyCarry
-		object.xvel = 0
-		object.yvel = 0
-		object.speed = 0
+	if player.state == PlayerObject_HandleFlyCarry
+		player.xvel = 0
+		player.yvel = 0
+		player.speed = 0
 	else
 		player[1].flyCarryTimer = 30
 	end if
@@ -2858,12 +2862,12 @@ end function
 
 function PlayerObject_HandleTailsFlight
 	CallFunction(PlayerObject_AirAcceleration)
-	if object.gravity == GRAVITY_AIR
-		object.xvel = object.speed
-		if object.yvel < -0x10000
+	if player.gravity == GRAVITY_AIR
+		player.xvel = player.speed
+		if player.yvel < -0x10000
 			player.flightVelocity = 0x800
 		else
-			if object.yvel < 1
+			if player.yvel < 1
 				if player.abilityTimer < 60
 					player.abilityTimer++
 				else
@@ -2872,14 +2876,14 @@ function PlayerObject_HandleTailsFlight
 			end if
 		end if
 
-		object.yvel += player.flightVelocity
+		player.yvel += player.flightVelocity
 		temp0 = stage.curYBoundary1
 		temp0 += 16
 		temp0 <<= 16
 
-		if object.ypos < temp0
-			if object.yvel < 0
-				object.yvel = 0
+		if player.ypos < temp0
+			if player.yvel < 0
+				player.yvel = 0
 			end if
 		end if
 
@@ -2890,31 +2894,31 @@ function PlayerObject_HandleTailsFlight
 		if player.timer < 480
 			if player.gravityStrength == 0x3800
 				if player[0].state == PlayerObject_HandleFlyCarry
-					if object.yvel < 0
-						object.animation = ANI_FLY_LIFT_UP
-						object.animationSpeed = 240
+					if player.yvel < 0
+						player.animation = ANI_FLY_LIFT_UP
+						player.animationSpeed = 240
 					else
-						object.animation = ANI_FLY_LIFT_DOWN
-						object.animationSpeed = 120
+						player.animation = ANI_FLY_LIFT_DOWN
+						player.animationSpeed = 120
 					end if
 				else
-					object.animation = ANI_FLYING
-					if object.yvel < 0
-						object.animationSpeed = 240
+					player.animation = ANI_FLYING
+					if player.yvel < 0
+						player.animationSpeed = 240
 					else
-						object.animationSpeed = 120
+						player.animationSpeed = 120
 					end if
 				end if
 			else
 				if player[0].state == PlayerObject_HandleFlyCarry
-					object.animation = ANI_SWIM_LIFT
+					player.animation = ANI_SWIM_LIFT
 				else
-					object.animation = ANI_SWIMMING
+					player.animation = ANI_SWIMMING
 					
-					if object.yvel < 0
-						object.animationSpeed = 60
+					if player.yvel < 0
+						player.animationSpeed = 60
 					else
-						object.animationSpeed = 30
+						player.animationSpeed = 30
 					end if
 				end if
 			end if
@@ -2923,23 +2927,23 @@ function PlayerObject_HandleTailsFlight
 			if player.timer == 480
 				if player.gravityStrength == 0x3800
 					if player[0].state == PlayerObject_HandleFlyCarry
-						object.animation = ANI_FLY_LIFT_TIRED
+						player.animation = ANI_FLY_LIFT_TIRED
 					else
-						object.animation = ANI_FLYINGTIRED
+						player.animation = ANI_FLYINGTIRED
 					end if
-					object.animationSpeed = 120
+					player.animationSpeed = 120
 
 					StopSfx(SfxName[Flying])
 					PlaySfx(SfxName[Tired], true)
 				else
 					if player[0].state == PlayerObject_HandleFlyCarry
-						object.animation = ANI_SWIM_LIFT
+						player.animation = ANI_SWIM_LIFT
 					else
-						object.animation = ANI_SWIMMINGTIRED
+						player.animation = ANI_SWIMMINGTIRED
 					end if
 				end if
 			else
-				if object.jumpPress == true
+				if player.jumpPress == true
 					CheckNotEqual(player.gravityStrength, 0x3800)
 					temp0 = checkResult
 					CheckEqual(player[0].state, PlayerObject_HandleFlyCarry)
@@ -2954,43 +2958,43 @@ function PlayerObject_HandleTailsFlight
 		else
 			if player.gravityStrength == 0x3800
 				if player[0].state == PlayerObject_HandleFlyCarry
-					object.animation = ANI_FLY_LIFT_TIRED
+					player.animation = ANI_FLY_LIFT_TIRED
 				else
-					object.animation = ANI_FLYINGTIRED
+					player.animation = ANI_FLYINGTIRED
 				end if
 			else
 				if player[0].state == PlayerObject_HandleFlyCarry
-					object.animation = ANI_SWIM_LIFT
+					player.animation = ANI_SWIM_LIFT
 				else
-					object.animation = ANI_SWIMMINGTIRED
+					player.animation = ANI_SWIMMINGTIRED
 				end if
 			end if
 		end if
 	else
-		object.animation = ANI_WALKING
-		object.state = PlayerObject_HandleGround
+		player.animation = ANI_WALKING
+		player.state = PlayerObject_HandleGround
 		CallFunction(PlayerObject_ResetOnFloor)
 	end if
 end function
 
 
 function PlayerObject_KnuxGlideLeft
-	if object.gravity == GRAVITY_AIR
-		if object.jumpHold == true
+	if player.gravity == GRAVITY_AIR
+		if player.jumpHold == true
 			if player.timer == 256
-				if object.speed < 0x180000
-					object.speed += 0x400
+				if player.speed < 0x180000
+					player.speed += 0x400
 				end if
 			else
-				if object.speed < 0x40000
-					object.speed += 0x1000
+				if player.speed < 0x40000
+					player.speed += 0x1000
 				end if
 			end if
 
-			if object.yvel > 0x8000
-				object.yvel -= 0x2000
+			if player.yvel > 0x8000
+				player.yvel -= 0x2000
 			else
-				object.yvel += 0x2000
+				player.yvel += 0x2000
 			end if
 
 			if player.timer < 256
@@ -2999,94 +3003,94 @@ function PlayerObject_KnuxGlideLeft
 
 			if player.timer < 170
 				if player.timer > 86
-					object.frame = 0
+					player.frame = 0
 				else
 					if player.timer > 44
-						object.frame = 1
+						player.frame = 1
 					else
-						object.frame = 2
+						player.frame = 2
 					end if
 				end if
 			else
 				if player.timer < 212
-					object.frame = 1
+					player.frame = 1
 				else
-					object.frame = 2
+					player.frame = 2
 				end if
 			end if
 
-			temp7 = object.xpos
+			temp7 = player.xpos
 			if player.timer < 128
-				object.direction = FLIP_NONE
+				player.direction = FLIP_NONE
 				temp0 = false
 				temp1 = false
 			else
-				object.direction = FLIP_X
-				object.xpos = temp7
-				object.xpos += object.xvel
-				object.ypos = object.ypos
-				ObjectTileCollision(CSIDE_RWALL, -12, -2, object.collisionPlane)
+				player.direction = FLIP_X
+				player.xpos = temp7
+				player.xpos += player.xvel
+				player.ypos = player.ypos
+				ObjectTileCollision(CSIDE_RWALL, -12, -2, player.collisionPlane)
 
 				temp0 = checkResult
-				temp2 = object.xpos
-				object.xpos = temp7
-				object.xpos += object.xvel
-				ObjectTileCollision(CSIDE_RWALL, -12, 11, object.collisionPlane)
+				temp2 = player.xpos
+				player.xpos = temp7
+				player.xpos += player.xvel
+				ObjectTileCollision(CSIDE_RWALL, -12, 11, player.collisionPlane)
 
 				temp1 = checkResult
-				temp3 = object.xpos
+				temp3 = player.xpos
 			end if
 
-			Cos(object.xvel, player.timer)
-			object.xvel *= object.speed
-			object.xvel >>= 9
+			Cos(player.xvel, player.timer)
+			player.xvel *= player.speed
+			player.xvel >>= 9
 
-			if object.right == true
-				object.state = PlayerObject_KnuxGlideRight
+			if player.right == true
+				player.state = PlayerObject_KnuxGlideRight
 			end if
 
-			object.xpos = temp7
+			player.xpos = temp7
 			checkResult = temp0
 			checkResult &= temp1
 			if checkResult == true
 				if temp2 == temp3
-					object.state = PlayerObject_KnuxWallClimb
-					object.speed = 0
-					object.xvel = 0
-					object.yvel = 0
+					player.state = PlayerObject_KnuxWallClimb
+					player.speed = 0
+					player.xvel = 0
+					player.yvel = 0
 					player.timer = 0
 					PlaySfx(SfxName[Catch], false)
 				else
 					player.timer = 0
-					object.xvel >>= 2
-					object.speed = object.xvel
-					object.animation = ANI_GLIDING_DROP
-					object.state = PlayerObject_KnuxGlideDrop
+					player.xvel >>= 2
+					player.speed = player.xvel
+					player.animation = ANI_GLIDING_DROP
+					player.state = PlayerObject_KnuxGlideDrop
 				end if
 			else
 				if temp0 == true
 					player.timer = 0
-					object.xvel >>= 2
-					object.speed = object.xvel
-					object.animation = ANI_GLIDING_DROP
-					object.state = PlayerObject_KnuxGlideDrop
+					player.xvel >>= 2
+					player.speed = player.xvel
+					player.animation = ANI_GLIDING_DROP
+					player.state = PlayerObject_KnuxGlideDrop
 				end if
 			end if
 		else
 			player.timer = 0
-			object.xvel >>= 2
-			object.speed = object.xvel
-			object.animation = ANI_GLIDING_DROP
-			object.state = PlayerObject_KnuxGlideDrop
+			player.xvel >>= 2
+			player.speed = player.xvel
+			player.animation = ANI_GLIDING_DROP
+			player.state = PlayerObject_KnuxGlideDrop
 		end if
 	else
-		if object.collisionMode == CMODE_FLOOR
+		if player.collisionMode == CMODE_FLOOR
 			player.timer = 0
-			object.state = PlayerObject_KnuxGlideSlide
-			object.animation = ANI_GLIDING_STOP
-			object.speed = object.xvel
+			player.state = PlayerObject_KnuxGlideSlide
+			player.animation = ANI_GLIDING_STOP
+			player.speed = player.xvel
 		else
-			object.state = PlayerObject_HandleGround
+			player.state = PlayerObject_HandleGround
 			CallFunction(PlayerObject_ResetOnFloor)
 			player.skidding = 0
 		end if
@@ -3095,30 +3099,30 @@ function PlayerObject_KnuxGlideLeft
 	temp0 = stage.curYBoundary1
 	temp0 += 16
 	temp0 <<= 16
-	if object.ypos < temp0
-		object.xvel = 0
-		object.speed = object.xvel
+	if player.ypos < temp0
+		player.xvel = 0
+		player.speed = player.xvel
 	end if
 end function
 
 
 function PlayerObject_KnuxGlideRight
-	if object.gravity == GRAVITY_AIR
-		if object.jumpHold == true
+	if player.gravity == GRAVITY_AIR
+		if player.jumpHold == true
 			if player.timer == 0
-				if object.speed < 0x180000
-					object.speed += 0x400
+				if player.speed < 0x180000
+					player.speed += 0x400
 				end if
 			else
-				if object.speed < 0x40000
-					object.speed += 0x1000
+				if player.speed < 0x40000
+					player.speed += 0x1000
 				end if
 			end if
 
-			if object.yvel > 0x8000
-				object.yvel -= 0x2000
+			if player.yvel > 0x8000
+				player.yvel -= 0x2000
 			else
-				object.yvel += 0x2000
+				player.yvel += 0x2000
 			end if
 
 			if player.timer > 0
@@ -3127,96 +3131,96 @@ function PlayerObject_KnuxGlideRight
 
 			if player.timer < 170
 				if player.timer > 86
-					object.frame = 0
+					player.frame = 0
 				else
 					if player.timer > 44
-						object.frame = 1
+						player.frame = 1
 					else
-						object.frame = 2
+						player.frame = 2
 					end if
 				end if
 			else
 				if player.timer < 212
-					object.frame = 1
+					player.frame = 1
 				else
-					object.frame = 2
+					player.frame = 2
 				end if
 			end if
 
-			temp7 = object.xpos
+			temp7 = player.xpos
 			if player.timer < 128
-				object.direction = FLIP_NONE
-				object.xpos = temp7
-				object.xpos += object.xvel
-				object.ypos = object.ypos
-				ObjectTileCollision(CSIDE_LWALL, 12, -2, object.collisionPlane)
+				player.direction = FLIP_NONE
+				player.xpos = temp7
+				player.xpos += player.xvel
+				player.ypos = player.ypos
+				ObjectTileCollision(CSIDE_LWALL, 12, -2, player.collisionPlane)
 
 				temp0 = checkResult
-				temp2 = object.xpos
-				object.xpos = temp7
-				object.xpos += object.xvel
-				ObjectTileCollision(CSIDE_LWALL, 12, 11, object.collisionPlane)
+				temp2 = player.xpos
+				player.xpos = temp7
+				player.xpos += player.xvel
+				ObjectTileCollision(CSIDE_LWALL, 12, 11, player.collisionPlane)
 
 				temp1 = checkResult
-				temp3 = object.xpos
+				temp3 = player.xpos
 			else
-				object.direction = FLIP_X
+				player.direction = FLIP_X
 				temp0 = false
 				temp1 = false
 			end if
 
-			Cos(object.xvel, player.timer)
-			object.xvel *= object.speed
-			object.xvel >>= 9
-			if object.left == true
-				object.state = PlayerObject_KnuxGlideLeft
+			Cos(player.xvel, player.timer)
+			player.xvel *= player.speed
+			player.xvel >>= 9
+			if player.left == true
+				player.state = PlayerObject_KnuxGlideLeft
 			end if
 
-			object.xpos = temp7
+			player.xpos = temp7
 			checkResult = temp0
 			checkResult &= temp1
 			if checkResult == true
 				temp2 >>= 1
 				temp3 >>= 1
 				if temp2 == temp3
-					object.state = PlayerObject_KnuxWallClimb
-					object.speed = 0
-					object.xvel = 0
-					object.yvel = 0
+					player.state = PlayerObject_KnuxWallClimb
+					player.speed = 0
+					player.xvel = 0
+					player.yvel = 0
 					player.timer = 0
 					PlaySfx(SfxName[Catch], false)
 				else
 					player.timer = 0
-					object.xvel >>= 2
-					object.speed = object.xvel
-					object.animation = ANI_GLIDING_DROP
-					object.state = PlayerObject_KnuxGlideDrop
+					player.xvel >>= 2
+					player.speed = player.xvel
+					player.animation = ANI_GLIDING_DROP
+					player.state = PlayerObject_KnuxGlideDrop
 				end if
 			else
 				if temp0 == true
-					object.speed = 0
+					player.speed = 0
 					player.timer = 0
-					object.xvel >>= 2
-					object.speed = object.xvel
-					object.animation = ANI_GLIDING_DROP
-					object.state = PlayerObject_KnuxGlideDrop
+					player.xvel >>= 2
+					player.speed = player.xvel
+					player.animation = ANI_GLIDING_DROP
+					player.state = PlayerObject_KnuxGlideDrop
 				end if
 			end if
 		else
 			player.timer = 0
-			object.xvel >>= 2
-			object.speed = object.xvel
-			object.animation = ANI_GLIDING_DROP
-			object.state = PlayerObject_KnuxGlideDrop
+			player.xvel >>= 2
+			player.speed = player.xvel
+			player.animation = ANI_GLIDING_DROP
+			player.state = PlayerObject_KnuxGlideDrop
 		end if
 	else
-		if object.collisionMode == CMODE_FLOOR
+		if player.collisionMode == CMODE_FLOOR
 			player.timer = 0
-			object.state = PlayerObject_KnuxGlideSlide
-			object.animation = ANI_GLIDING_STOP
-			object.speed = object.xvel
+			player.state = PlayerObject_KnuxGlideSlide
+			player.animation = ANI_GLIDING_STOP
+			player.speed = player.xvel
 		else
-			object.state = PlayerObject_HandleGround
+			player.state = PlayerObject_HandleGround
 			CallFunction(PlayerObject_ResetOnFloor)
 			player.skidding = 0
 		end if
@@ -3225,15 +3229,15 @@ function PlayerObject_KnuxGlideRight
 	temp0 = stage.curYBoundary1
 	temp0 += 16
 	temp0 <<= 16
-	if object.ypos < temp0
-		object.xvel = 0
-		object.speed = object.xvel
+	if player.ypos < temp0
+		player.xvel = 0
+		player.speed = player.xvel
 	end if
 end function
 
 
 function PlayerObject_KnuxGlideDrop
-	if object.gravity == GRAVITY_AIR
+	if player.gravity == GRAVITY_AIR
 		CallFunction(PlayerObject_AirAcceleration)
 		CallFunction(PlayerObject_HandleAirMovement)
 	else
@@ -3241,17 +3245,17 @@ function PlayerObject_KnuxGlideDrop
 			PlaySfx(SfxName[Landing], false)
 		end if
 
-		object.scrollTracking = 0
-		object.speed = 0
-		object.xvel = 0
-		object.animation = ANI_LOOKINGDOWN
-		object.prevAnimation = ANI_LOOKINGDOWN
-		object.frame = 2
+		player.scrollTracking = 0
+		player.speed = 0
+		player.xvel = 0
+		player.animation = ANI_LOOKINGDOWN
+		player.prevAnimation = ANI_LOOKINGDOWN
+		player.frame = 2
 
 		if player.timer < 16
 			player.timer++
 		else
-			object.state = PlayerObject_HandleGround
+			player.state = PlayerObject_HandleGround
 			CallFunction(PlayerObject_ResetOnFloor)
 			player.skidding = 0
 		end if
@@ -3260,21 +3264,21 @@ end function
 
 
 function PlayerObject_KnuxGlideSlide
-	if object.gravity == GRAVITY_GROUND
-		if object.speed == 0
-			object.scrollTracking = false
-			object.frame = 1
+	if player.gravity == GRAVITY_GROUND
+		if player.speed == 0
+			player.scrollTracking = false
+			player.frame = 1
 			if player.timer < 16
 				player.timer++
 			else
-				object.state = PlayerObject_HandleGround
+				player.state = PlayerObject_HandleGround
 				CallFunction(PlayerObject_ResetOnFloor)
 				player.skidding = 0
 			end if
 		else
 			if ringTimer == 0
-				CreateTempObject(TypeName[Dust Puff], 0, object.xpos, object.ypos)
-				object[tempObjectPos].iypos += object.collisionBottom
+				CreateTempObject(TypeName[Dust Puff], 0, player.xpos, player.ypos)
+				object[tempObjectPos].iypos += player.collisionBottom
 				object[tempObjectPos].drawOrder = player.sortedDrawOrder
 
 				if player.timer == 0
@@ -3285,177 +3289,177 @@ function PlayerObject_KnuxGlideSlide
 				end if
 			end if
 
-			object.frame = 0
-			if object.speed > 0
-				object.speed -= 0x2000
-				if object.speed < 0
-					object.speed = 0
+			player.frame = 0
+			if player.speed > 0
+				player.speed -= 0x2000
+				if player.speed < 0
+					player.speed = 0
 					player.timer = 0
 				end if
 			else
-				object.speed += 0x2000
-				if object.speed > 0
-					object.speed = 0
+				player.speed += 0x2000
+				if player.speed > 0
+					player.speed = 0
 					player.timer = 0
 				end if
 			end if
 
-			if object.jumpHold == false
-				object.speed = 0
+			if player.jumpHold == false
+				player.speed = 0
 				player.timer = 0
 			end if
 		end if
 
-		object.xvel = object.speed
+		player.xvel = player.speed
 	else
 		player.timer = 0
-		object.animation = ANI_GLIDING_DROP
-		object.state = PlayerObject_KnuxGlideDrop
+		player.animation = ANI_GLIDING_DROP
+		player.state = PlayerObject_KnuxGlideDrop
 	end if
 end function
 
 
 function PlayerObject_KnuxWallClimb
-	if object.gravity == GRAVITY_AIR
-		object.animation = ANI_CLIMBING
-		if object.up == true
+	if player.gravity == GRAVITY_AIR
+		player.animation = ANI_CLIMBING
+		if player.up == true
 			if PlayerObject_SuperState == SUPERSTATE_SUPER
-				object.yvel = -0x20000
+				player.yvel = -0x20000
 			else
-				object.yvel = -0x10000
+				player.yvel = -0x10000
 			end if
-			temp0 = object.collisionTop
+			temp0 = player.collisionTop
 			temp0 *= -0x10000
 
-			if object.ypos < temp0
-				object.ypos = temp0
+			if player.ypos < temp0
+				player.ypos = temp0
 			end if
 
 			player.timer++
 			if player.timer == 4
 				player.timer = 0
-				object.frame++
-				object.frame %= 6
+				player.frame++
+				player.frame %= 6
 			end if
 		else
-			if object.down == true
+			if player.down == true
 				if PlayerObject_SuperState == SUPERSTATE_SUPER
-					object.yvel = 0x20000
+					player.yvel = 0x20000
 				else
-					object.yvel = 0x10000
+					player.yvel = 0x10000
 				end if
 
 				player.timer++
 				if player.timer == 4
 					player.timer = 0
-					if object.frame < 1
-						object.frame += 6
+					if player.frame < 1
+						player.frame += 6
 					end if
 
-					object.frame--
+					player.frame--
 				end if
 			else
-				object.yvel = 0
+				player.yvel = 0
 			end if
 		end if
 
-		if object.jumpPress == true
-			object.animation = ANI_JUMPING
-			object.state = PlayerObject_HandleAir
+		if player.jumpPress == true
+			player.animation = ANI_JUMPING
+			player.state = PlayerObject_HandleAir
 			player.timer = 0
 			PlaySfx(SfxName[Jump], false)
 
-			if object.direction == FLIP_X
-				object.xvel = 0x40000
-				object.speed = 0x40000
-				object.direction = FLIP_NONE
+			if player.direction == FLIP_X
+				player.xvel = 0x40000
+				player.speed = 0x40000
+				player.direction = FLIP_NONE
 			else
-				object.xvel = -0x40000
-				object.speed = -0x40000
-				object.direction = FLIP_X
+				player.xvel = -0x40000
+				player.speed = -0x40000
+				player.direction = FLIP_X
 			end if
 
-			object.yvel = -0x40000
+			player.yvel = -0x40000
 			if player.gravityStrength != 0x3800
-				object.xvel >>= 1
-				object.speed >>= 1
-				object.yvel >>= 1
+				player.xvel >>= 1
+				player.speed >>= 1
+				player.yvel >>= 1
 			end if
 		else
-			if object.direction == FLIP_NONE
-				temp2 = object.xpos
-				ObjectTileGrip(CSIDE_LWALL, 10, -10, object.collisionPlane)
+			if player.direction == FLIP_NONE
+				temp2 = player.xpos
+				ObjectTileGrip(CSIDE_LWALL, 10, -10, player.collisionPlane)
 
 				temp0 = checkResult
-				temp3 = object.xpos
-				object.xpos = temp2
-				ObjectTileGrip(CSIDE_LWALL, 10, 11, object.collisionPlane)
+				temp3 = player.xpos
+				player.xpos = temp2
+				ObjectTileGrip(CSIDE_LWALL, 10, 11, player.collisionPlane)
 
 				temp1 = checkResult
-				if object.xpos > temp3
-					object.xpos = temp3
+				if player.xpos > temp3
+					player.xpos = temp3
 				end if
 			else
-				temp2 = object.xpos
-				ObjectTileGrip(CSIDE_RWALL, -10, -10, object.collisionPlane)
+				temp2 = player.xpos
+				ObjectTileGrip(CSIDE_RWALL, -10, -10, player.collisionPlane)
 
 				temp0 = checkResult
-				temp3 = object.xpos
-				object.xpos = temp2
-				ObjectTileGrip(CSIDE_RWALL, -10, 11, object.collisionPlane)
+				temp3 = player.xpos
+				player.xpos = temp2
+				ObjectTileGrip(CSIDE_RWALL, -10, 11, player.collisionPlane)
 
 				temp1 = checkResult
-				if object.xpos < temp3
-					object.xpos = temp3
+				if player.xpos < temp3
+					player.xpos = temp3
 				end if
 			end if
 
 			if temp0 == false
-				object.xpos = temp2
-				object.animation = ANI_LEDGEPULLUP
-				object.yvel = 0
+				player.xpos = temp2
+				player.animation = ANI_LEDGEPULLUP
+				player.yvel = 0
 				player.timer = 0
-				object.state = PlayerObject_KnuxLedgePullUp
-				object.tileCollisions = false
+				player.state = PlayerObject_KnuxLedgePullUp
+				player.tileCollisions = false
 
-				if object.direction == FLIP_NONE
-					object.xpos += 0x10000
+				if player.direction == FLIP_NONE
+					player.xpos += 0x10000
 				end if
 			else
 				if temp1 == false
-					object.animation = ANI_GLIDING_DROP
-					object.prevAnimation = ANI_GLIDING_DROP
-					object.frame = 2
+					player.animation = ANI_GLIDING_DROP
+					player.prevAnimation = ANI_GLIDING_DROP
+					player.frame = 2
 					player.timer = 0
-					object.state = PlayerObject_KnuxGlideDrop
+					player.state = PlayerObject_KnuxGlideDrop
 				end if
 			end if
 		end if
 	else
-		object.animation = ANI_WALKING
-		object.state = PlayerObject_HandleGround
+		player.animation = ANI_WALKING
+		player.state = PlayerObject_HandleGround
 		CallFunction(PlayerObject_ResetOnFloor)
 	end if
 end function
 
 
 function PlayerObject_KnuxLedgePullUp
-	switch object.frame
+	switch player.frame
 	case 0
 		if player.timer < 5
-			ObjectTileGrip(CSIDE_FLOOR, 12, -9, object.collisionPlane)
+			ObjectTileGrip(CSIDE_FLOOR, 12, -9, player.collisionPlane)
 			player.timer++
 		else
 			player.timer = 0
-			object.frame++
+			player.frame++
 
-			if object.direction == FLIP_NONE
-				object.xpos += 0x90000
+			if player.direction == FLIP_NONE
+				player.xpos += 0x90000
 			else
-				object.xpos -= 0x90000
+				player.xpos -= 0x90000
 			end if
 
-			object.ypos -= 0xA0000
+			player.ypos -= 0xA0000
 		end if
 		break
 
@@ -3464,15 +3468,15 @@ function PlayerObject_KnuxLedgePullUp
 			player.timer++
 		else
 			player.timer = 0
-			object.frame++
+			player.frame++
 
-			if object.direction == FLIP_NONE
-				object.xpos += 0x50000
+			if player.direction == FLIP_NONE
+				player.xpos += 0x50000
 			else
-				object.xpos -= 0x50000
+				player.xpos -= 0x50000
 			end if
 
-			object.ypos -= 0x20000
+			player.ypos -= 0x20000
 		end if
 		break
 
@@ -3481,10 +3485,10 @@ function PlayerObject_KnuxLedgePullUp
 			player.timer++
 		else
 			player.timer = 0
-			object.animation = ANI_STOPPED
-			object.state = PlayerObject_HandleAir
-			object.ypos -= 0xA0000
-			object.tileCollisions = true
+			player.animation = ANI_STOPPED
+			player.state = PlayerObject_HandleAir
+			player.ypos -= 0xA0000
+			player.tileCollisions = true
 		end if
 		break
 	end switch
@@ -3493,7 +3497,7 @@ end function
 
 function PlayerObject_Hurt
 	if player.isSidekick == false
-		arrayPos0 = object.entityPos
+		arrayPos0 = player.entityPos
 		arrayPos0 += playerCount
 		if player.shield != SHIELD_NONE
 			temp0 = 1
@@ -3531,38 +3535,38 @@ function PlayerObject_Hurt
 		end if
 	end if
 
-	object.visible = true
+	player.visible = true
 	switch temp0
 	default
 	case 0
 		break
 
 	case 1
-		object.state = PlayerObject_Knockback
-		object.animation = ANI_HURT
-		object.yvel = -0x40000
-		object.gravity = GRAVITY_AIR
-		object.scrollTracking = 1
-		object.tileCollisions = 1
+		player.state = PlayerObject_Knockback
+		player.animation = ANI_HURT
+		player.yvel = -0x40000
+		player.gravity = GRAVITY_AIR
+		player.scrollTracking = 1
+		player.tileCollisions = 1
 		player.blinkTimer = 120
 
 		if player.gravityStrength == 0x1000
-			object.speed >>= 1
-			object.yvel >>= 1
+			player.speed >>= 1
+			player.yvel >>= 1
 		end if
 		break
 
 	case 2
-		object.state = PlayerObject_Knockback
-		object.animation = ANI_HURT
-		object.yvel = -0x40000
-		object.gravity = GRAVITY_AIR
-		object.scrollTracking = true
-		object.tileCollisions = true
+		player.state = PlayerObject_Knockback
+		player.animation = ANI_HURT
+		player.yvel = -0x40000
+		player.gravity = GRAVITY_AIR
+		player.scrollTracking = true
+		player.tileCollisions = true
 		player.blinkTimer = 120
 		if player.gravityStrength == 0x1000
-			object.speed >>= 1
-			object.yvel >>= 1
+			player.speed >>= 1
+			player.yvel >>= 1
 		end if
 
 		temp0 = player.rings
@@ -3591,7 +3595,7 @@ function PlayerObject_Hurt
 
 		temp3 = 0
 		while temp3 < temp1
-			CreateTempObject(TypeName[Lose Ring], object.collisionPlane, object.xpos, object.ypos)
+			CreateTempObject(TypeName[Lose Ring], player.collisionPlane, player.xpos, player.ypos)
 			Cos(object[tempObjectPos].xvel, temp2)
 			Sin(object[tempObjectPos].yvel, temp2)
 			object[tempObjectPos].xvel <<= 8
@@ -3616,7 +3620,7 @@ function PlayerObject_Hurt
 
 		temp3 = 0
 		while temp3 < temp0
-			CreateTempObject(TypeName[Lose Ring], object.collisionPlane, object.xpos, object.ypos)
+			CreateTempObject(TypeName[Lose Ring], player.collisionPlane, player.xpos, player.ypos)
 			Cos(object[tempObjectPos].xvel, temp2)
 			Sin(object[tempObjectPos].yvel, temp2)
 			object[tempObjectPos].xvel <<= 9
@@ -3633,16 +3637,16 @@ function PlayerObject_Hurt
 
 	case 3
 		player.sortedDrawOrder = 6
-		object.speed = 0
-		object.yvel = -0x70000
-		object.xvel = 0
-		object.state = PlayerObject_Death
-		object.animation = ANI_DYING
-		object.tileCollisions = false
-		object.interaction = false
+		player.speed = 0
+		player.yvel = -0x70000
+		player.xvel = 0
+		player.state = PlayerObject_Death
+		player.animation = ANI_DYING
+		player.tileCollisions = false
+		player.interaction = false
 
-		if object.entityPos == screen.cameraTarget
-			object.priority = PRIORITY_ACTIVE_PAUSED
+		if player.entityPos == screen.cameraTarget
+			player.priority = PRIORITY_ACTIVE_PAUSED
 			if player[1].type == TypeName[Player 2 Object]
 				player[1].priority = PRIORITY_ACTIVE_PAUSED
 			end if
@@ -3665,19 +3669,19 @@ end function
 
 
 function PlayerObject_Knockback
-	if object.gravity == GRAVITY_AIR
-		object.scrollTracking = true
+	if player.gravity == GRAVITY_AIR
+		player.scrollTracking = true
 		if player.gravityStrength == 0x3800
-			object.yvel += 0x3000
+			player.yvel += 0x3000
 		else
-			object.yvel += 0xF00
+			player.yvel += 0xF00
 		end if
 
-		object.xvel = object.speed
+		player.xvel = player.speed
 	else
-		object.state = PlayerObject_HandleGround
-		object.speed = 0
-		object.xvel = 0
+		player.state = PlayerObject_HandleGround
+		player.speed = 0
+		player.xvel = 0
 		CallFunction(PlayerObject_ResetOnFloor)
 	end if
 end function
@@ -3725,7 +3729,7 @@ function PlayerObject_Death
 			if options.vsMode == false
 				stage.timeEnabled = false
 
-				object.type = TypeName[Death Event]
+				player.type = TypeName[Death Event]
 				deathEvent.drawOrder 	= 6
 				deathEvent.leftTextPos 	= screen.xcenter
 				deathEvent.leftTextPos -= 264
@@ -3762,7 +3766,7 @@ function PlayerObject_Death
 					deathEvent.state = DEATHEVENT_TIMEOVER
 				end if
 
-				if object.type == TypeName[Death Event]
+				if player.type == TypeName[Death Event]
 					deathEvent.drawOrder = 6
 					deathEvent.leftTextPos = screen.xcenter
 					deathEvent.leftTextPos -= 264
@@ -3772,34 +3776,34 @@ function PlayerObject_Death
 					PlayMusic(TRACK_GAMEOVER)
 					stage.pauseEnabled = false
 				else
-					object.state 		= PlayerObject_HandleAir
+					player.state 		= PlayerObject_HandleAir
 					player.rings 		= 0
-					object.priority 	= PRIORITY_ACTIVE
-					object.gravity 		= GRAVITY_AIR
-					object.animation 	= ANI_HURT
-					if object.entityPos == 0
-						object.xpos = vs.restartX1
-						object.ypos = vs.restartY1
+					player.priority 	= PRIORITY_ACTIVE
+					player.gravity 		= GRAVITY_AIR
+					player.animation 	= ANI_HURT
+					if player.entityPos == 0
+						player.xpos = vs.restartX1
+						player.ypos = vs.restartY1
 					else
-						object.xpos = vs.restartX2
-						object.ypos = vs.restartY2
+						player.xpos = vs.restartX2
+						player.ypos = vs.restartY2
 					end if
-					object.direction 		= FLIP_NONE
-					object.tileCollisions 	= true
-					object.interaction 		= true
-					object.visible 			= true
+					player.direction 		= FLIP_NONE
+					player.tileCollisions 	= true
+					player.interaction 		= true
+					player.visible 			= true
 					player.controlMode 		= 0
-					object.scrollTracking 	= true
-					object.drawOrder 		= DRAWORDER_PLAYER
+					player.scrollTracking 	= true
+					player.drawOrder 		= DRAWORDER_PLAYER
 					player.sortedDrawOrder 	= 4
-					object.collisionPlane 	= PATH_A
+					player.collisionPlane 	= PATH_A
 
-					if object.entityPos == screen.cameraTarget
-						CreateTempObject(TypeName[VS Game], 0, object.xpos, object.ypos)
+					if player.entityPos == screen.cameraTarget
+						CreateTempObject(TypeName[VS Game], 0, player.xpos, player.ypos)
 						vsGame[tempObjectPos].timer = 384
 						vsGame[tempObjectPos].state = VSGAME_FADEOUT
-						screen.cameraX = object.ixpos
-						screen.cameraY = object.iypos
+						screen.cameraX = player.ixpos
+						screen.cameraY = player.iypos
 						screen.cameraEnabled = true
 					end if
 				end if
@@ -3810,29 +3814,29 @@ end function
 
 
 function PlayerObject_Drown
-	if object.entityPos == 0
+	if player.entityPos == 0
 		if PlayerObject_SuperState == SUPERSTATE_SUPER
 			PlayerObject_SuperState = SUPERSTATE_FADEOUT
 		end if
 	end if
 
 	player.controlMode 	= -1
-	object.yvel 	   += player.gravityStrength
-	object.animation 	= ANI_DROWNING
-	if object.entityPos == screen.cameraTarget
+	player.yvel 	   += player.gravityStrength
+	player.animation 	= ANI_DROWNING
+	if player.entityPos == screen.cameraTarget
 		temp0   = screen.cameraY
 		temp0  += 272
 		temp0 <<= 16
-		if object.ypos > temp0
-			object.ypos = temp0
+		if player.ypos > temp0
+			player.ypos = temp0
 		end if
 	end if
 
-	if object.yvel > 0x80000
+	if player.yvel > 0x80000
 		if player.isSidekick == false
 			// global variable "array" (yes, this is actually how its done)
 			arrayPos0 = VarName[player.lives]
-			arrayPos0 += object.entityPos
+			arrayPos0 += player.entityPos
 			if global[arrayPos0] > 0
 				global[arrayPos0]--
 			end if
@@ -3840,7 +3844,7 @@ function PlayerObject_Drown
 			if options.vsMode == false
 				stage.timeEnabled 		= false
 
-				object.type 			= TypeName[Death Event]
+				player.type 			= TypeName[Death Event]
 				deathEvent.drawOrder 	= 6
 				deathEvent.leftTextPos 	= screen.xcenter
 				deathEvent.leftTextPos -= 264
@@ -3861,34 +3865,34 @@ function PlayerObject_Drown
 					end if
 				end if
 			else
-				object.state 		= PlayerObject_HandleAir
+				player.state 		= PlayerObject_HandleAir
 				player.rings 		= 0
-				object.priority 	= PRIORITY_ACTIVE
-				object.gravity 		= GRAVITY_AIR
-				object.animation 	= ANI_HURT
-				if object.entityPos == 0
-					object.xpos = vs.restartX1
-					object.ypos = vs.restartY1
+				player.priority 	= PRIORITY_ACTIVE
+				player.gravity 		= GRAVITY_AIR
+				player.animation 	= ANI_HURT
+				if player.entityPos == 0
+					player.xpos = vs.restartX1
+					player.ypos = vs.restartY1
 				else
-					object.xpos = vs.restartX2
-					object.ypos = vs.restartY2
+					player.xpos = vs.restartX2
+					player.ypos = vs.restartY2
 				end if
 
-				object.direction 		= FLIP_NONE
-				object.tileCollisions 	= true
-				object.interaction 		= true
-				object.visible 			= true
+				player.direction 		= FLIP_NONE
+				player.tileCollisions 	= true
+				player.interaction 		= true
+				player.visible 			= true
 				player.controlMode 		= 0
-				object.scrollTracking 	= true
-				object.drawOrder 		= DRAWORDER_PLAYER
+				player.scrollTracking 	= true
+				player.drawOrder 		= DRAWORDER_PLAYER
 				player.sortedDrawOrder 	= 4
-				object.collisionPlane 	= PATH_A
-				if object.entityPos == screen.cameraTarget
-					CreateTempObject(TypeName[VS Game], 0, object.xpos, object.ypos)
+				player.collisionPlane 	= PATH_A
+				if player.entityPos == screen.cameraTarget
+					CreateTempObject(TypeName[VS Game], 0, player.xpos, player.ypos)
 					vsGame[tempObjectPos].timer = 384
 					vsGame[tempObjectPos].state = VSGAME_FADEOUT
-					screen.cameraX = object.ixpos
-					screen.cameraY = object.iypos
+					screen.cameraX = player.ixpos
+					screen.cameraY = player.iypos
 					screen.cameraEnabled = true
 				end if
 			end if
@@ -3900,112 +3904,114 @@ end function
 // Wacky Workbench hanging bar gimmick
 // Unused leftover from CD
 function PlayerObject_HangingBar
-	if object.left == true
-		object.direction = FLIP_X
-		object.speed = -0x20000
-		object.animationSpeed = 30
+	if player.left == true
+		player.direction = FLIP_X
+		player.speed = -0x20000
+		player.animationSpeed = 30
 	else
-		if object.right == true
-			object.direction = FLIP_NONE
-			object.speed = 0x20000
-			object.animationSpeed = 30
+		if player.right == true
+			player.direction = FLIP_NONE
+			player.speed = 0x20000
+			player.animationSpeed = 30
 		else
-			object.speed = 0
-			object.animationSpeed = 0
+			player.speed = 0
+			player.animationSpeed = 0
 		end if
 	end if
 
-	temp1 = object.xpos
+	temp1 = player.xpos
 	temp1 >>= 16
-	temp2 = object.ypos
+	temp2 = player.ypos
 	temp2 >>= 16
-	temp2 += object.collisionTop
+	temp2 += player.collisionTop
 	Get16x16TileInfo(temp0, temp1, temp2, TILEINFO_ANGLEB)
 	if temp0 != 3
-		object.state = PlayerObject_HandleAir
-		object.speed = 0
-		object.animationSpeed = 0
-		object.yvel = 0
+		player.state = PlayerObject_HandleAir
+		player.speed = 0
+		player.animationSpeed = 0
+		player.yvel = 0
 	end if
 
-	if object.jumpPress == true
-		object.state = PlayerObject_HandleAir
-		object.yvel = 0
-		object.speed = 0
-		object.animationSpeed = 0
-		object.ypos += 0x40000
+	if player.jumpPress == true
+		player.state = PlayerObject_HandleAir
+		player.yvel = 0
+		player.speed = 0
+		player.animationSpeed = 0
+		player.ypos += 0x40000
 	end if
-	object.xvel = object.speed
+	player.xvel = player.speed
 end function
 
 
 function PlayerObject_TubeSwitch
-	if object.gravity == GRAVITY_AIR
-		object.state = PlayerObject_AirCtrlLock
+	if player.gravity == GRAVITY_AIR
+		player.state = PlayerObject_AirCtrlLock
 		player.timer = 0
 		CallFunction(PlayerObject_HandleAirMovement)
 	else
-		if object.speed > 0
-			if object.collisionMode == CMODE_FLOOR
-				if object.speed < 0x10000
-					object.speed = 0x40000
+		if player.speed > 0
+			if player.collisionMode == CMODE_FLOOR
+				if player.speed < 0x10000
+					player.speed = 0x40000
 				end if
 			end if
 		else
-			if object.collisionMode == CMODE_FLOOR
-				if object.speed > -0x10000
-					object.speed = -0x40000
+			if player.collisionMode == CMODE_FLOOR
+				if player.speed > -0x10000
+					player.speed = -0x40000
 				end if
 			end if
 		end if
 
-		if object.right == true
-			if object.speed < 0
-				object.speed += player.rollingDeceleration
+		if player.right == true
+			if player.speed < 0
+				player.speed += player.rollingDeceleration
 			end if
 		end if
 
-		if object.left == true
-			if object.speed > 0
-				object.speed -= player.rollingDeceleration
+		if player.left == true
+			if player.speed > 0
+				player.speed -= player.rollingDeceleration
 			end if
 		end if
 		
-		if object.speed > 0
-			object.speed -= player.rollingFriction
-			Sin256(temp0, object.angle)
+		if player.speed > 0
+			player.speed -= player.rollingFriction
+			Sin256(temp0, player.angle)
 			if temp0 > 0
-				Sin256(temp0, object.angle)
+				Sin256(temp0, player.angle)
 				temp0 *= 0x5000
 			else
-				Sin256(temp0, object.angle)
+				Sin256(temp0, player.angle)
 				temp0 *= 0x1E00
 			end if
 			temp0 >>= 8
 
-			object.speed += temp0
+			player.speed += temp0
 		else
-			object.speed += player.rollingFriction
-			Sin256(temp0, object.angle)
+			player.speed += player.rollingFriction
+			Sin256(temp0, player.angle)
 			if temp0 < 0
-				Sin256(temp0, object.angle)
+				Sin256(temp0, player.angle)
 				temp0 *= 0x5000
 			else
-				Sin256(temp0, object.angle)
+				Sin256(temp0, player.angle)
 				temp0 *= 0x1E00
 			end if
 			temp0 >>= 8
 
-			object.speed += temp0
+			player.speed += temp0
 		end if
 
 		CallFunction(PlayerObject_RollAnimSpd)
-		object.animationSpeed = player.customRollAnimSpeed
+		player.animationSpeed = player.customRollAnimSpeed
 		CallFunction(PlayerObject_ResetOnFloor)
 	end if
 end function
 
 
+// Unused state
+// WFZ's clinging just uses an identical duplicate of this instead, stored within the stage's setup script
 function PlayerObject_Clinging
 	player.gravity = GRAVITY_AIR
 	if player.animation != ANI_CLINGING
@@ -4100,12 +4106,13 @@ event ObjectMain
 			player.drownLevel = 0
 			player.frame = debugMode.currentSelection
 			screen.cameraEnabled = true
-			screen.cameraStyle = 0
+			screen.cameraStyle = CAMERASTYLE_FOLLOW
 			player.hitboxLeft 	= HITBOX_AUTO
 			player.hitboxTop 	= HITBOX_AUTO
 			player.hitboxRight 	= HITBOX_AUTO
 			player.hitboxBottom = HITBOX_AUTO
 
+			// This pretty much only happens when the player died, but now that they're entering Debug Mode, everything can be restored again
 			if stage.state == STAGE_FROZEN
 				stage.state = STAGE_RUNNING
 			end if
@@ -4141,10 +4148,10 @@ event ObjectMain
 				temp0 = player.prevGravity
 				player.prevGravity = player.gravity
 				ProcessObjectMovement()
-				player.prevGravity ^= 1
+				player.prevGravity ^= GRAVITY_AIR
 				CheckEqual(player.gravity, GRAVITY_GROUND)
 				player.prevGravity |= checkResult
-				player.prevGravity ^= 1
+				player.prevGravity ^= GRAVITY_AIR
 
 				if temp0 == GRAVITY_AIR
 					if player.prevGravity == GRAVITY_GROUND
@@ -4196,10 +4203,10 @@ event ObjectMain
 			temp0 = player.prevGravity
 			player.prevGravity = player.gravity
 			ProcessObjectMovement()
-			player.prevGravity ^= 1
+			player.prevGravity ^= GRAVITY_AIR
 			CheckEqual(player.gravity, GRAVITY_GROUND)
 			player.prevGravity |= checkResult
-			player.prevGravity ^= 1
+			player.prevGravity ^= GRAVITY_AIR
 
 			if temp0 == GRAVITY_GROUND
 				if player.prevGravity == GRAVITY_GROUND
@@ -4234,7 +4241,7 @@ end event
 event ObjectDraw
 	if player.animation != player.prevAnimation
 		// If the player's animation is different than the one they had last frame,
-		// Reset all the other animation values too
+		// eeset all the other animation values too
 		player.prevAnimation = player.animation
 		player.frame = 0
 		player.animationTimer = 0
@@ -4250,7 +4257,7 @@ event ObjectStartup
 
 	foreach (TypeName[Player Object], arrayPos0, ALL_ENTITIES)
 		screen.cameraEnabled = true
-		screen.cameraStyle = 0
+		screen.cameraStyle = CAMERASTYLE_FOLLOW
 		screen.cameraTarget = 0
 
 		currentPlayer = 0
@@ -4300,7 +4307,8 @@ event ObjectStartup
 			LoadAnimation("Tails.ani")
 			player[0].jumpOffset = -1
 
-			if options.vsMode == true // Tails can always fly in 2P VS
+			if options.vsMode == true
+				// Tails can always fly in 2P VS, regardless of the setting
 				options.tailsFlight = true
 			end if
 

--- a/Sonic 2/Scripts/SCZ/SCZSetup.txt
+++ b/Sonic 2/Scripts/SCZ/SCZSetup.txt
@@ -35,6 +35,10 @@ private alias 0 : TRACK_STAGE
 // Reserved object slots
 private alias 10 : SLOT_ZONESETUP
 
+// Music Loops
+private alias 198253 : MUSIC_LOOP_SCZ
+
+
 // ========================
 // Static Values
 // ========================
@@ -276,7 +280,7 @@ end event
 
 event ObjectStartup
 
-	SetMusicTrack("SkyChase.ogg", TRACK_STAGE, 198253)
+	SetMusicTrack("SkyChase.ogg", TRACK_STAGE, MUSIC_LOOP_SCZ)
 
 	// Set the "inhabitants" of this zone
 	// I sure hope they can fly...

--- a/Sonic 2/Scripts/Special/PlayerObject.txt
+++ b/Sonic 2/Scripts/Special/PlayerObject.txt
@@ -9,8 +9,31 @@
 // Aliases
 // ========================
 
-private alias object.xpos : player.xpos
-private alias object.ypos : player.ypos
+private alias object.type 			: player.type
+private alias object.entityPos 		: player.entityPos
+private alias object.state 			: player.state
+private alias object.priority 		: player.priority
+private alias object.visible 		: player.visible
+private alias object.xpos 			: player.xpos
+private alias object.ypos 			: player.ypos
+private alias object.xvel 			: player.xvel
+private alias object.yvel 			: player.yvel
+private alias object.speed 			: player.speed
+private alias object.rotation 		: player.rotation
+private alias object.angle 			: player.angle
+private alias object.frame 			: player.frame
+private alias object.animation 		: player.animation
+private alias object.animationSpeed : player.animationSpeed
+private alias object.animationTimer : player.animationTimer
+private alias object.gravity 		: player.gravity
+private alias object.controlMode 	: player.controlMode
+
+private alias object.up 		: player.up
+private alias object.down 		: player.down
+private alias object.left 		: player.left
+private alias object.right 		: player.right
+private alias object.jumpPress 	: player.jumpPress
+private alias object.jumpHold 	: player.jumpHold
 
 private alias object.value0  : player.rings
 private alias object.value1  : player.timer
@@ -52,6 +75,7 @@ private alias object.value19 : halfpipe.worldRotation.z
 // LoseRing Aliases
 private alias object.value1 : loseRing.gravityStrength
 
+
 // ========================
 // Function Declarations
 // ========================
@@ -63,6 +87,7 @@ reserve function PlayerObject_HurtSpin
 reserve function PlayerObject_RingLoss
 reserve function PlayerObject_ProcessDrawing
 reserve function PlayerObject_Process2PVSPlayer
+
 
 // ========================
 // Static Values
@@ -556,32 +581,32 @@ function PlayerObject_HandleGround
 	temp0 = player.rotation
 	player.changedLeader = false
 
-	if object.jumpPress == true
-		object.speed = 0
-		Sin(object.xvel, object.rotation)
-		object.xvel *= 0x5A0
-		object.xvel >>= 9
-		Cos(object.yvel, object.rotation)
-		object.yvel *= 0x980
-		object.yvel >>= 9
-		object.state = PlayerObject_HandleAir
-		object.rotation = 0
-		object.frame = 8
-		object.frame += object.frameOffset
-		object.animation = 8
-		object.animationSpeed = 60
-		object.animationTimer = 0
-		object.gravity = GRAVITY_AIR
+	if player.jumpPress == true
+		player.speed = 0
+		Sin(player.xvel, player.rotation)
+		player.xvel *= 0x5A0
+		player.xvel >>= 9
+		Cos(player.yvel, player.rotation)
+		player.yvel *= 0x980
+		player.yvel >>= 9
+		player.state = PlayerObject_HandleAir
+		player.rotation = 0
+		player.frame = 8
+		player.frame += player.frameOffset
+		player.animation = 8
+		player.animationSpeed = 60
+		player.animationTimer = 0
+		player.gravity = GRAVITY_AIR
 		PlaySfx(SfxName[Jump], false)
 	else
-		if object.rotation > 152
-			if object.rotation < 360
-				if object.speed < 128
-					if object.speed > -128
-						object.xvel = object.speed
-						object.speed = 0
-						object.state = PlayerObject_HandleAir
-						object.yvel = 0
+		if player.rotation > 152
+			if player.rotation < 360
+				if player.speed < 128
+					if player.speed > -128
+						player.xvel = player.speed
+						player.speed = 0
+						player.state = PlayerObject_HandleAir
+						player.yvel = 0
 					end if
 				end if
 			end if
@@ -595,127 +620,127 @@ function PlayerObject_HandleGround
 		end if
 	end if
 
-	Sin(object.shadowPos.x, temp0)
-	object.shadowPos.x *= -52
-	object.shadowPos.x >>= 1
+	Sin(player.shadowPos.x, temp0)
+	player.shadowPos.x *= -52
+	player.shadowPos.x >>= 1
 
-	Cos(object.shadowPos.y, temp0)
-	object.shadowPos.y *= -52
-	object.shadowPos.y >>= 1
+	Cos(player.shadowPos.y, temp0)
+	player.shadowPos.y *= -52
+	player.shadowPos.y >>= 1
 
-	object.shadowPos.u = 116
+	player.shadowPos.u = 116
 
 	if temp0 < 256
 		if temp0 > 112
-			object.shadowPos.u = 224
+			player.shadowPos.u = 224
 		else
 			if temp0 > 39
-				object.shadowPos.u = 149
+				player.shadowPos.u = 149
 			end if
 		end if
 	else
 		if temp0 < 400
-			object.shadowPos.u = 215
+			player.shadowPos.u = 215
 		else
 			if temp0 < 473
-				object.shadowPos.u = 182
+				player.shadowPos.u = 182
 			end if
 		end if
 	end if
 
-	if object.rotation < 40
-		object.rotation = 0
+	if player.rotation < 40
+		player.rotation = 0
 	end if
 
-	if object.rotation > 472
-		object.rotation = 0
+	if player.rotation > 472
+		player.rotation = 0
 	end if
 end function
 
 
 function PlayerObject_HandleAir
 	if options.vsMode == true
-		if object.changedLeader == false
+		if player.changedLeader == false
 			PlayerObject_leadingPlayer ^= 1
-			object.changedLeader = true
+			player.changedLeader = true
 		end if
 	end if
 
-	object.xpos += object.xvel
-	if object.xpos <= object.xBoundsL
-		object.xpos = object.xBoundsL
+	player.xpos += player.xvel
+	if player.xpos <= player.xBoundsL
+		player.xpos = player.xBoundsL
 	end if
 
-	if object.xpos >= object.xBoundsR
-		object.xpos = object.xBoundsR
+	if player.xpos >= player.xBoundsR
+		player.xpos = player.xBoundsR
 	end if
 
-	if object.left == true
-		object.xvel -= 32
+	if player.left == true
+		player.xvel -= 32
 	end if
 
-	if object.right == true
-		object.xvel += 32
+	if player.right == true
+		player.xvel += 32
 	end if
 
-	object.ypos += object.yvel
-	object.yvel -= 88
-	if object.ypos < 0
-		temp0 = object.xpos
-		temp0 *= object.xpos
-		temp1 = object.ypos
-		temp1 *= object.ypos
+	player.ypos += player.yvel
+	player.yvel -= 88
+	if player.ypos < 0
+		temp0 = player.xpos
+		temp0 *= player.xpos
+		temp1 = player.ypos
+		temp1 *= player.ypos
 		temp0 += temp1
-		if temp0 > object.groundPos
-			object.state = PlayerObject_HandleGround
-			object.gravity = GRAVITY_GROUND
-			ATan2(object.angle, object.ypos, object.xpos)
-			object.angle += 128
-			object.angle <<= 8
+		if temp0 > player.groundPos
+			player.state = PlayerObject_HandleGround
+			player.gravity = GRAVITY_GROUND
+			ATan2(player.angle, player.ypos, player.xpos)
+			player.angle += 128
+			player.angle <<= 8
 		end if
 	end if
 
-	if object.rotation < 0x100
-		if object.rotation > 0
-			object.rotation -= 8
+	if player.rotation < 0x100
+		if player.rotation > 0
+			player.rotation -= 8
 		else
-			object.rotation = 0
+			player.rotation = 0
 		end if
 	else
-		if object.rotation < 0x200
-			object.rotation += 8
+		if player.rotation < 0x200
+			player.rotation += 8
 		else
-			object.rotation = 0
+			player.rotation = 0
 		end if
 	end if
 
-	object.shadowPos.x = object.xpos
-	object.shadowPos.x *= 144
-	object.shadowPos.x >>= 8
+	player.shadowPos.x = player.xpos
+	player.shadowPos.x *= 144
+	player.shadowPos.x >>= 8
 
-	temp0 = object.xpos
+	temp0 = player.xpos
 	temp0 *= 45
 	temp0 >>= 13
 	Abs(temp0)
-	GetTableValue(object.shadowPos.y, temp0, PlayerObject_shadowYPosTable)
-	temp0 = object.shadowPos.y
-	object.shadowPos.y *= 105
+	GetTableValue(player.shadowPos.y, temp0, PlayerObject_shadowYPosTable)
+	temp0 = player.shadowPos.y
+	player.shadowPos.y *= 105
 
-	object.shadowPos.u = 116
+	player.shadowPos.u = 116
 
 	// Shadow frame funky stuff
 	if temp0 > -112
 		if temp0 > -24
-			if object.xpos < 0
-				object.shadowPos.u = 224
+			if player.xpos < 0
+				player.shadowPos.u = 224
 			else
-				object.shadowPos.u = 215
+				player.shadowPos.u = 215
 			end if
 		else
-			if object.xpos < 0
-				object.shadowPos.u = 149
+			if player.xpos < 0
+				player.shadowPos.u = 149
 			else
-				object.shadowPos.u = 182
+				player.shadowPos.u = 182
 			end if
 		end if
 	end if
@@ -725,27 +750,27 @@ end function
 function PlayerObject_HurtSpin
 	if options.vsMode == true
 		if vs.playerID == 0
-			if object.changedLeader == false
-				PlayerObject_leadingPlayer = object.entityPos
+			if player.changedLeader == false
+				PlayerObject_leadingPlayer = player.entityPos
 				PlayerObject_leadingPlayer -= 2
 				PlayerObject_leadingPlayer ^= vs.playerID
 				PlayerObject_leadingPlayer ^= 1
-				object.changedLeader = true
+				player.changedLeader = true
 			end if
 		end if
 	end if
 	
-	if object.spinTimer < 512
-		object.spinTimer += 16
-		object.rotation += 16
+	if player.spinTimer < 512
+		player.spinTimer += 16
+		player.rotation += 16
 	else
-		object.speed = 0
-		object.spinTimer = 0
-		object.invincibilityTimer = 60
-		if object.gravity == GRAVITY_GROUND
-			object.state = PlayerObject_HandleGround
+		player.speed = 0
+		player.spinTimer = 0
+		player.invincibilityTimer = 60
+		if player.gravity == GRAVITY_GROUND
+			player.state = PlayerObject_HandleGround
 		else
-			object.state = PlayerObject_HandleAir
+			player.state = PlayerObject_HandleAir
 		end if
 	end if
 end function
@@ -767,14 +792,14 @@ function PlayerObject_RingLoss
 		temp2 <<= 5
 		temp1 = 384
 		temp1 -= temp2
-		temp2 = object.angle
+		temp2 = player.angle
 		temp2 >>= 7
 		temp1 += temp2
 		temp3 = player[currentPlayer].xpos
 		temp3 *= 224
 		temp4 = player[currentPlayer].ypos
 		temp4 *= -220
-		temp5 = object[2].ypos
+		temp5 = player[2].ypos
 		temp5 *= -48
 		temp4 += 0x600000
 		temp4 += temp5
@@ -801,42 +826,42 @@ end function
 // ========================
 
 event ObjectMain
-	CallFunction(object.stateInput)
-	CallFunction(object.state)
+	CallFunction(player.stateInput)
+	CallFunction(player.state)
 
 	if options.vsMode == true
-		temp0 = object.entityPos
+		temp0 = player.entityPos
 		temp0 -= 2
 		temp0 ^= vs.playerID
 		temp0 ^= PlayerObject_leadingPlayer
 		if temp0 == 0
-			if object.zpos < 0x1000
-				object.zpos += 64
+			if player.zpos < 0x1000
+				player.zpos += 64
 			end if
 		else
-			if object.zpos > 0x400
-				object.zpos -= 64
+			if player.zpos > 0x400
+				player.zpos -= 64
 			end if
 		end if
 	end if
 
-	object.stagePos.z = object.zpos
-	object.stagePos.z <<= 8
-	object.stagePos.z += halfpipe[0].playerPos.z
-	object.stagePos.z += 0xC0000
+	player.stagePos.z = player.zpos
+	player.stagePos.z <<= 8
+	player.stagePos.z += halfpipe[0].playerPos.z
+	player.stagePos.z += 0xC0000
 
-	object.animationTimer += object.animationSpeed
-	if object.animationTimer >= 240
-		object.animationTimer -= 240
-		object.frame++
-		object.frame &= 7
-		object.frame += object.animation
-		object.frame += object.frameOffset
+	player.animationTimer += player.animationSpeed
+	if player.animationTimer >= 240
+		player.animationTimer -= 240
+		player.frame++
+		player.frame &= 7
+		player.frame += player.animation
+		player.frame += player.frameOffset
 	end if
 
 	CallFunction(PlayerObject_ProcessDrawing)
-	object.playerFrame++
-	object.playerFrame %= 28
+	player.playerFrame++
+	player.playerFrame %= 28
 end event
 
 
@@ -913,77 +938,77 @@ event ObjectStartup
 	SpriteFrame(-8, -40, 16, 7, 348, 100)
 	SpriteFrame(-8, -40, 16, 7, 348, 108)
 
-	object[2].type = TypeName[Player Object]
-	object[2].priority = PRIORITY_ACTIVE
-	object[2].zpos = 0x1000
-	object[2].state = PlayerObject_HandleGround
-	object[2].stateInput = PlayerObject_ProcessP1Inputs
+	player[2].type = TypeName[Player Object]
+	player[2].priority = PRIORITY_ACTIVE
+	player[2].zpos = 0x1000
+	player[2].state = PlayerObject_HandleGround
+	player[2].stateInput = PlayerObject_ProcessP1Inputs
 	switch stage.playerListPos
 	case PlayerName[SONIC]
-		object[2].xBoundsR = 88
-		object[2].frameOffset = 0
+		player[2].xBoundsR = 88
+		player[2].frameOffset = 0
 		break
 
 	case PlayerName[TAILS]
-		object[2].xBoundsR = 90
-		object[2].frameOffset = 16
+		player[2].xBoundsR = 90
+		player[2].frameOffset = 16
 		break
 		
 	case PlayerName[KNUCKLES]
-		object[2].xBoundsR = 88
-		object[2].frameOffset = 32
+		player[2].xBoundsR = 88
+		player[2].frameOffset = 32
 		break
 
 	end switch
 
-	object[2].xBoundsR <<= 8
-	object[2].xBoundsL = object[2].xBoundsR
-	FlipSign(object[2].xBoundsL)
-	object[2].groundPos = object[2].xBoundsR
-	object[2].groundPos *= object[2].xBoundsR
-	object[2].groundPos -= 0x10000
-	object[2].frame = object[2].frameOffset
+	player[2].xBoundsR <<= 8
+	player[2].xBoundsL = player[2].xBoundsR
+	FlipSign(player[2].xBoundsL)
+	player[2].groundPos = player[2].xBoundsR
+	player[2].groundPos *= player[2].xBoundsR
+	player[2].groundPos -= 0x10000
+	player[2].frame = player[2].frameOffset
 
 	if options.vsMode == true
-		object[3].type = TypeName[Player Object]
-		object[3].priority = PRIORITY_ACTIVE
-		object[3].playerTagFrame = vs.playerID
-		object[3].playerTagFrame ^= 1
-		object[3].playerTagFrame += 55
+		player[3].type = TypeName[Player Object]
+		player[3].priority = PRIORITY_ACTIVE
+		player[3].playerTagFrame = vs.playerID
+		player[3].playerTagFrame ^= 1
+		player[3].playerTagFrame += 55
 		if vs.playerID == 0
-			object[2].zpos = 0x1000
-			object[3].zpos = 0x400
+			player[2].zpos = 0x1000
+			player[3].zpos = 0x400
 		else
-			object[2].zpos = 0x400
-			object[3].zpos = 0x1000
+			player[2].zpos = 0x400
+			player[3].zpos = 0x1000
 		end if
 
-		object[3].state = PlayerObject_HandleGround
-		object[3].stateInput = PlayerObject_Process2PVSPlayer
+		player[3].state = PlayerObject_HandleGround
+		player[3].stateInput = PlayerObject_Process2PVSPlayer
 		switch vs.player2Type
 		case PlayerName[SONIC]
-			object[3].xBoundsR = 88
-			object[3].frameOffset = 0
+			player[3].xBoundsR = 88
+			player[3].frameOffset = 0
 			break
 
 		case PlayerName[TAILS]
-			object[3].xBoundsR = 90
-			object[3].frameOffset = 16
+			player[3].xBoundsR = 90
+			player[3].frameOffset = 16
 			break
 
 		case PlayerName[KNUCKLES]
-			object[3].xBoundsR = 88
-			object[3].frameOffset = 32
+			player[3].xBoundsR = 88
+			player[3].frameOffset = 32
 			break
 		end switch
 
-		object[3].xBoundsR <<= 8
-		object[3].xBoundsL = object[3].xBoundsR
-		FlipSign(object[3].xBoundsL)
-		object[3].groundPos = object[3].xBoundsR
-		object[3].groundPos *= object[3].xBoundsR
-		object[3].groundPos -= 0x10000
-		object[3].frame = object[3].frameOffset
+		player[3].xBoundsR <<= 8
+		player[3].xBoundsL = player[3].xBoundsR
+		FlipSign(player[3].xBoundsL)
+		player[3].groundPos = player[3].xBoundsR
+		player[3].groundPos *= player[3].xBoundsR
+		player[3].groundPos -= 0x10000
+		player[3].frame = player[3].frameOffset
 
 		stage.player2Enabled = false
 		playerCount = 2
@@ -992,20 +1017,20 @@ event ObjectStartup
 	end if
 
 	if stage.player2Enabled == true
-		object[3].type = TypeName[Player Object]
-		object[3].priority = PRIORITY_ACTIVE
-		object[3].zpos = 0x400
-		object[3].state = PlayerObject_HandleAir
-		object[3].stateInput = PlayerObject_ProcessP2Inputs
-		object[3].xBoundsR = 90
-		object[3].frameOffset = 16
-		object[3].xBoundsR <<= 8
-		object[3].xBoundsL = object[3].xBoundsR
-		FlipSign(object[3].xBoundsL)
-		object[3].groundPos = object[3].xBoundsR
-		object[3].groundPos *= object[3].xBoundsR
-		object[3].groundPos -= 0x10000
-		object[3].frame = object[3].frameOffset
+		player[3].type = TypeName[Player Object]
+		player[3].priority = PRIORITY_ACTIVE
+		player[3].zpos = 0x400
+		player[3].state = PlayerObject_HandleAir
+		player[3].stateInput = PlayerObject_ProcessP2Inputs
+		player[3].xBoundsR = 90
+		player[3].frameOffset = 16
+		player[3].xBoundsR <<= 8
+		player[3].xBoundsL = player[3].xBoundsR
+		FlipSign(player[3].xBoundsL)
+		player[3].groundPos = player[3].xBoundsR
+		player[3].groundPos *= player[3].xBoundsR
+		player[3].groundPos -= 0x10000
+		player[3].frame = player[3].frameOffset
 	end if
 end event
 

--- a/Sonic 2/Scripts/Special/SpecialSetup.txt
+++ b/Sonic 2/Scripts/Special/SpecialSetup.txt
@@ -35,6 +35,10 @@ private alias 10 : SLOT_SPECIALHUD
 private alias 0 : TRACK_STAGE
 private alias 1 : TRACK_ACTFINISH
 
+// Music Loops
+private alias 496644 : MUSIC_LOOP_SPECIAL
+
+
 // ========================
 // Static Values
 // ========================
@@ -102,7 +106,7 @@ end event
 
 
 event ObjectStartup
-	SetMusicTrack("SpecialStage.ogg", TRACK_STAGE, 496644)
+	SetMusicTrack("SpecialStage.ogg", TRACK_STAGE, MUSIC_LOOP_SPECIAL)
 	SetMusicTrack("ActComplete.ogg", TRACK_ACTFINISH, false)
 	SpecialSetup_gotEmerald = false
 

--- a/Sonic 2/Scripts/WFZ/WFZSetup.txt
+++ b/Sonic 2/Scripts/WFZ/WFZSetup.txt
@@ -51,6 +51,15 @@ private alias 0 : MUSICEVENT_FLAG_NOCHANGE
 private alias 1 : MUSICEVENT_FLAG_SPEEDUP
 private alias 2 : MUSICEVENT_FLAG_SLOWDOWN
 
+
+// Music Loops
+private alias 99874 : MUSIC_LOOP_WFZ
+private alias 80074 : MUSIC_LOOP_WFZ_F
+
+private alias 38679 : MUSIC_LOOP_INV
+private alias 30897 : MUSIC_LOOP_INV_F
+
+
 // ========================
 // Function Declarations
 // ========================
@@ -118,20 +127,20 @@ function WFZSetup_SpeedUpMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
-			SwapMusicTrack("WingFortress_F.ogg", TRACK_STAGE, 80074, 8000)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
+			SwapMusicTrack("WingFortress_F.ogg", TRACK_STAGE, MUSIC_LOOP_WFZ_F, 8000)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("WingFortress_F.ogg", TRACK_STAGE, 80074)
-			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897, 8000)
+			SetMusicTrack("WingFortress_F.ogg", TRACK_STAGE, MUSIC_LOOP_WFZ_F)
+			SwapMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F, 8000)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("WingFortress_F.ogg", TRACK_STAGE, 80074)
-			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, 30897)
+			SetMusicTrack("WingFortress_F.ogg", TRACK_STAGE, MUSIC_LOOP_WFZ_F)
+			SetMusicTrack("Invincibility_F.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV_F)
 			break
 		end switch
 	else
@@ -150,20 +159,20 @@ function WFZSetup_SlowDownMusic
 	if temp0 == false
 		switch music.currentTrack
 		case TRACK_STAGE
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
-			SwapMusicTrack("WingFortress.ogg", TRACK_STAGE, 99874, 12500)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
+			SwapMusicTrack("WingFortress.ogg", TRACK_STAGE, MUSIC_LOOP_WFZ, 12500)
 			break
 
 		case TRACK_INVINCIBLE
-			SetMusicTrack("WingFortress.ogg", TRACK_STAGE, 99874)
-			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679, 12500)
+			SetMusicTrack("WingFortress.ogg", TRACK_STAGE, MUSIC_LOOP_WFZ)
+			SwapMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV, 12500)
 			break
 
 		case TRACK_BOSS
 		case TRACK_DROWNING
 		case TRACK_SUPER
-			SetMusicTrack("WingFortress.ogg", TRACK_STAGE, 99874)
-			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, 38679)
+			SetMusicTrack("WingFortress.ogg", TRACK_STAGE, MUSIC_LOOP_WFZ)
+			SetMusicTrack("Invincibility.ogg", TRACK_INVINCIBLE, MUSIC_LOOP_INV)
 			break
 		end switch
 	else
@@ -221,7 +230,7 @@ end event
 
 
 event ObjectStartup
-	SetMusicTrack("WingFortress.ogg", TRACK_STAGE, 99874)
+	SetMusicTrack("WingFortress.ogg", TRACK_STAGE, MUSIC_LOOP_WFZ)
 
 	SpeedUpMusic = WFZSetup_SpeedUpMusic
 	SlowDownMusic = WFZSetup_SlowDownMusic


### PR DESCRIPTION
This commit fixes an issue where Tails's tails would show while he was in his ANI_PEELOUT animation, with the animation ID seemingly confused for the Spindash one instead. There are also a few other changes, namely
- Fixing the Sonic 2 Special Stage compile issues
- Giving most music loops identifiable aliases
- Hopefully ironing out the last of the static value mod compatibility problems
- A few Player Object tweaks
- Enforcing a tab size of 4 when viewing from github.com