### PR TITLE
Fix ARZ/LeafSpawner.txt RE2 ObjectDef

### DIFF
--- a/Sonic 2/Scripts/ARZ/LeafSpawner.txt
+++ b/Sonic 2/Scripts/ARZ/LeafSpawner.txt
@@ -121,14 +121,15 @@ event RSDKDraw
 		// Draw the object's hitbox
 		// Intentionally ignoring editor.drawingOveraly here
 
-		temp0 = 32
-		temp0 <<= object.propertyValue
-		temp0 *= 0x2
-		temp1 = temp0
-		temp1 += object.xpos
-		temp2 = object.ypos
-		temp2 -= 32
-		DrawRectOutline(temp1, temp2, temp0, 64, 255, 0, 0, 255)
+		// Right hitbox
+		temp2 = 32
+		temp2 <<= object.propertyValue
+		
+		// Left hitbox (just mirrored)
+		temp0 = temp2
+		
+		temp1 = 32; temp3 = 32;
+		CallFunction(EditorHelpers_DrawHitbox)
 	end if
 end event
 


### PR DESCRIPTION
While bringing this object over for a different project I noticed that the hit box in RE2 Doesn't draw correctly
How it draws:
<img width="381" height="237" alt="image" src="https://github.com/user-attachments/assets/4f25fc2f-0f83-436d-900d-be63cbc771e3" />

How it should draw:
<img width="622" height="270" alt="image" src="https://github.com/user-attachments/assets/54782029-5483-4a63-8904-8f0f52f14e03" />
